### PR TITLE
added qtensor class

### DIFF
--- a/src/tequila/__init__.py
+++ b/src/tequila/__init__.py
@@ -4,6 +4,7 @@ from tequila.hamiltonian import paulis, QubitHamiltonian, PauliString
 from tequila.objective import Objective, VectorObjective,\
     ExpectationValue, Variable, assign_variable, format_variable_dictionary,\
     vectorize
+from tequila.objective import QTensor
 
 from tequila.optimizers import INSTALLED_OPTIMIZERS, show_available_optimizers
 from tequila.optimizers import minimize, minimize_scipy, minimize_gd, optimizer_scipy

--- a/src/tequila/objective/__init__.py
+++ b/src/tequila/objective/__init__.py
@@ -1,3 +1,5 @@
 from tequila.objective.objective import Objective,\
     VectorObjective, ExpectationValue, Variable, assign_variable, format_variable_list, \
     format_variable_dictionary,vectorize
+
+from tequila.objective.qtensor import QTensor

--- a/src/tequila/objective/qtensor.py
+++ b/src/tequila/objective/qtensor.py
@@ -1,0 +1,199 @@
+import numpy
+from .objective import Objective, ExpectationValueImpl, format_variable_dictionary
+from tequila import TequilaException
+
+class QTensor(numpy.ndarray):
+    # see here: https://numpy.org/devdocs/user/basics.subclassing.html
+    
+    def __new__(subtype, objective_list=None, *args, **kwargs):
+        if "dtype" not in kwargs:
+            kwargs["dtype"] = Objective
+        return super().__new__(subtype, *args, **kwargs)
+    
+    def __init__(self, objective_list=None, *args, **kwargs):
+        super().__init__()
+        # do all-zero initialization
+        shape = self.shape
+        if objective_list is None:
+            with numpy.nditer(self, flags =["refs_ok"], op_flags=['readwrite']) as it:
+                for x in it:
+                    x[...] = Objective()
+        else:
+            j=0
+            with numpy.nditer(self, flags =["refs_ok"], op_flags=['readwrite']) as it:
+                for x in it:
+                    x[...] = objective_list[j]
+                    j=j+1
+    
+    def __call__(self,variables=None, *args, **kwargs):
+#         helper = lambda x: x(*args, **kwargs)
+#         ff = numpy.vectorize(helper)
+#         return ff(self)
+        """
+        Return the output of the calculation the objective represents.
+
+        Parameters
+        ----------
+        variables: dict:
+            dictionary instantiating all variables that may appear within the objective.
+        args
+        kwargs
+
+        Returns
+        -------
+        float:
+            the result of the calculation represented by this objective.
+        """
+        variables = format_variable_dictionary(variables)
+        # failsafe
+        check_variables = {k: k in variables for k in self.extract_variables()}
+        if not all(list(check_variables.values())):
+            raise TequilaException("Objective did not receive all variables:\n"
+                                   "You gave\n"
+                                   " {}\n"
+                                   " but the objective depends on\n"
+                                   " {}\n"
+                                   " missing values for\n"
+                                   " {}".format(variables, self.extract_variables(), [k for k,v in check_variables.items() if not v]))
+
+        # avoid multiple evaluations
+        evaluated = {}
+        ev_array = []
+        newtensor = self.flatten()
+        for obj in newtensor:
+            a = obj(variables=variables, *args, **kwargs)
+            ev_array.append(a)
+#             print(obj)
+#             for E in obj.args:
+#                 if E not in evaluated:#
+#                     expval_result = E(variables=variables, *args, **kwargs)
+#                     evaluated[E] = expval_result
+#                 else:
+#                     expval_result = evaluated[E]
+#                 try:
+#                     expval_result = float(expval_result)
+#                 except:
+#                     pass # allow array evaluation (non-standard operation)
+#                 print('\n expected value results:',expval_result)
+#             ev_array.append(a)
+            #result.append(numpy.asarray(newtensor[i].transformation(*ev_array),dtype=float))
+        
+        ev_array = numpy.reshape(ev_array,self.shape)
+        if ev_array.shape == ():
+            return float(ev_array)
+        elif len(ev_array) == 1:
+            return float(ev_array[0])
+        else:
+            return ev_array
+        
+    def apply(self, fn):
+        _f = self.HelperObject(func=fn)
+        _fn = numpy.vectorize(_f)
+        return _fn(self)
+    
+    def extract_variables(self)->list:
+        newtensor = self.flatten()
+        unique = []
+        for obj in newtensor:
+            if hasattr(obj, 'extract_variables'):
+                var_list = obj.extract_variables()
+                for j in var_list:
+                    if j not in unique:
+                        unique.append(j)
+        return unique
+       
+    
+    def get_expectationvalues(self):
+        """
+        Returns
+        -------
+        list:
+            all the expectation values that make up the objective.
+        """
+        newtensor = self.flatten()
+        expvals = []
+        for obj in newtensor:
+            if hasattr(obj, 'get_expectationvalues'):
+                expvals += obj.get_expectationvalues()
+        return expvals
+    
+    def count_measurements(self):
+        """
+        Count all measurements necessary for this objective:
+        Function will iterate to all unique expectation values and count the
+        number of Pauli strings in the corresponding Hamiltonians
+        Returns
+        -------
+        Number of measurements required for this objective
+        Measurements can be on different circuits (with regards to gates, depth, size, qubits)
+        """
+        return sum(E.count_measurements() for E in list(set(self.get_expectationvalues())))
+    
+    def count_expectationvalues(self, unique=True):
+        """
+        Parameters
+        ----------
+        unique: bool:
+            whether or not to count identical expectationvalues as distinct.
+
+        Returns
+        -------
+        int:
+            how many (possibly, how many unique) expectationvalues are contained within the objective.
+
+        """
+        if unique:
+            return len(set(self.get_expectationvalues()))
+        else:
+            return len(self.get_expectationvalues())
+    
+    def __repr__(self): ## should give back a tensor
+#         return "f({})".format(self.extract_variables())
+        _repmat = numpy.empty(self.shape,dtype = object)
+        _repmat = _repmat.flatten()
+        newtensor = self.flatten()
+        for i in range(len(newtensor)):
+            _repmat[i] = repr(newtensor[i])
+        _repmat = _repmat.reshape(self.shape)
+        return repr(_repmat) #"f({})".format(self.extract_variables())
+    
+    def __str__(self):
+        variables = self.extract_variables()
+        if len(variables) > 5:
+            variables = len(variables)
+
+        newtensor = self.flatten()
+        types = []
+        for obj in newtensor:
+            if hasattr(obj, 'get_expectationvalues'):
+                _types = [type(E) for E in obj.get_expectationvalues()]
+                for tt in _types:
+                    types.append(tt)
+        types = list(set(types))
+        if ExpectationValueImpl in types:
+            if len(types) == 1:
+                types = "not compiled"
+            else:
+                types = "partially compiled to " + str([t for t in types if t is not ExpectationValueImpl])
+
+        unique = self.count_expectationvalues(unique=True)
+        measurements = self.count_measurements()
+        return "QTensor of shape {} with {} unique expectation values\n" \
+              "total measurements = {}\n" \
+              "variables          = {}\n" \
+              "types              = {}".format(self.shape, unique, measurements, variables, types)
+    
+    class HelperObject:
+        """
+        This is a small helper object class for tequila objectives
+        it is within the QTensor class to shield it from the outside (meant for internal use)
+        create if like this:
+            ff = HelperObject(func=f) where f is the function you want to apply later (e.g. numpy.sin)
+        use if like this with tequila objectives
+            f_on_objective = ff(objective) 
+        """
+        def __init__(self, func):
+            self.func = func
+        def __call__(self, objective):
+            return objective.apply(self.func)
+

--- a/src/tequila/objective/qtensor.py
+++ b/src/tequila/objective/qtensor.py
@@ -4,12 +4,12 @@ from tequila import TequilaException
 
 class QTensor(numpy.ndarray):
     # see here: https://numpy.org/devdocs/user/basics.subclassing.html
-    
+
     def __new__(subtype, objective_list=None, *args, **kwargs):
         if "dtype" not in kwargs:
             kwargs["dtype"] = Objective
         return super().__new__(subtype, *args, **kwargs)
-    
+
     def __init__(self, objective_list=None, *args, **kwargs):
         super().__init__()
         # do all-zero initialization
@@ -24,11 +24,8 @@ class QTensor(numpy.ndarray):
                 for x in it:
                     x[...] = objective_list[j]
                     j=j+1
-    
+
     def __call__(self,variables=None, *args, **kwargs):
-#         helper = lambda x: x(*args, **kwargs)
-#         ff = numpy.vectorize(helper)
-#         return ff(self)
         """
         Return the output of the calculation the objective represents.
 
@@ -63,21 +60,6 @@ class QTensor(numpy.ndarray):
         for obj in newtensor:
             a = obj(variables=variables, *args, **kwargs)
             ev_array.append(a)
-#             print(obj)
-#             for E in obj.args:
-#                 if E not in evaluated:#
-#                     expval_result = E(variables=variables, *args, **kwargs)
-#                     evaluated[E] = expval_result
-#                 else:
-#                     expval_result = evaluated[E]
-#                 try:
-#                     expval_result = float(expval_result)
-#                 except:
-#                     pass # allow array evaluation (non-standard operation)
-#                 print('\n expected value results:',expval_result)
-#             ev_array.append(a)
-            #result.append(numpy.asarray(newtensor[i].transformation(*ev_array),dtype=float))
-        
         ev_array = numpy.reshape(ev_array,self.shape)
         if ev_array.shape == ():
             return float(ev_array)
@@ -85,12 +67,12 @@ class QTensor(numpy.ndarray):
             return float(ev_array[0])
         else:
             return ev_array
-        
+
     def apply(self, fn):
         _f = self.HelperObject(func=fn)
         _fn = numpy.vectorize(_f)
         return _fn(self)
-    
+
     def extract_variables(self)->list:
         newtensor = self.flatten()
         unique = []
@@ -101,8 +83,7 @@ class QTensor(numpy.ndarray):
                     if j not in unique:
                         unique.append(j)
         return unique
-       
-    
+
     def get_expectationvalues(self):
         """
         Returns
@@ -116,7 +97,7 @@ class QTensor(numpy.ndarray):
             if hasattr(obj, 'get_expectationvalues'):
                 expvals += obj.get_expectationvalues()
         return expvals
-    
+
     def count_measurements(self):
         """
         Count all measurements necessary for this objective:
@@ -128,7 +109,7 @@ class QTensor(numpy.ndarray):
         Measurements can be on different circuits (with regards to gates, depth, size, qubits)
         """
         return sum(E.count_measurements() for E in list(set(self.get_expectationvalues())))
-    
+
     def count_expectationvalues(self, unique=True):
         """
         Parameters
@@ -146,22 +127,20 @@ class QTensor(numpy.ndarray):
             return len(set(self.get_expectationvalues()))
         else:
             return len(self.get_expectationvalues())
-    
-    def __repr__(self): ## should give back a tensor
-#         return "f({})".format(self.extract_variables())
+
+    def __repr__(self):
         _repmat = numpy.empty(self.shape,dtype = object)
         _repmat = _repmat.flatten()
         newtensor = self.flatten()
         for i in range(len(newtensor)):
             _repmat[i] = repr(newtensor[i])
         _repmat = _repmat.reshape(self.shape)
-        return repr(_repmat) #"f({})".format(self.extract_variables())
-    
+        return repr(_repmat)
+
     def __str__(self):
         variables = self.extract_variables()
         if len(variables) > 5:
             variables = len(variables)
-
         newtensor = self.flatten()
         types = []
         for obj in newtensor:
@@ -182,7 +161,7 @@ class QTensor(numpy.ndarray):
               "total measurements = {}\n" \
               "variables          = {}\n" \
               "types              = {}".format(self.shape, unique, measurements, variables, types)
-    
+
     class HelperObject:
         """
         This is a small helper object class for tequila objectives
@@ -196,4 +175,3 @@ class QTensor(numpy.ndarray):
             self.func = func
         def __call__(self, objective):
             return objective.apply(self.func)
-

--- a/tests/test_qtensor.py
+++ b/tests/test_qtensor.py
@@ -1,10 +1,80 @@
 import tequila as tq
 import numpy
 
+def make_expval_list():
+    H = tq.paulis.X(0)
+    Hz = tq.paulis.Z(0)
+    U1 = tq.gates.Ry(angle='a',target=0)
+    U2 = tq.gates.X(0)+U1
+
+    U3 = tq.gates.Ry(angle='b',target=0)
+
+    E1 = tq.ExpectationValue(H=H, U=U1) # result is 1
+    E2 = tq.ExpectationValue(H=H, U=U2) # result is -1
+    E3 = tq.ExpectationValue(H=H, U=U1+U3)
+    return [E1, E2, E3, E1]
+
 def test_qtensor_with_numbers():
     list1 = [0.5+tq.Objective(),1.5+tq.Objective(),0.75+tq.Objective(),2+tq.Objective()]
     list2 = [1+tq.Objective(),1+tq.Objective()]
     mat1 = tq.QTensor(objective_list=list1,shape = [2,2])
     vec1 = tq.QTensor(objective_list=list2,shape = [2])
     res = tq.simulate(numpy.dot(mat1,vec1))
-    assert res[0] == 2.
+    numpy.testing.assert_allclose(res,[2, 2.75])
+
+def test_qtensor_with_objectives():
+    list1 = make_expval_list()
+    mat1  = tq.QTensor(objective_list=list1, shape=(2,2))
+    E = tq.simulate(mat1, {'a':1.0,'b':0.5})
+    F = numpy.array([[0.84147098, -0.84147098],[0.99749499, 0.84147098]])
+    numpy.testing.assert_allclose(E,F)
+
+def test_apply():
+    list1 = make_expval_list()
+    mat1  = tq.QTensor(objective_list=list1, shape=(2,2))
+    mat2 = mat1.apply(numpy.exp)
+    E = tq.simulate(mat2, {'a':1.0,'b':0.5})
+    F = numpy.array([[2.31977682, 0.43107595], [2.71148102, 2.31977682]])
+    numpy.testing.assert_allclose(E,F)
+
+def test_count_expval():
+    list1 = make_expval_list()
+    mat1  = tq.QTensor(objective_list=list1, shape=(2,2))
+    E = mat1.count_expectationvalues()
+    assert E == 3
+
+def test_add():
+    list1 = make_expval_list()
+    mat1  = tq.QTensor(objective_list=list1, shape=(2,2))
+    E = tq.simulate(mat1+mat1,{'a':1.0,'b':0.5})
+    F = tq.simulate(2*mat1,{'a':1.0,'b':0.5})
+    G = tq.simulate(mat1*2,{'a':1.0,'b':0.5})
+    H = tq.simulate(2*mat1+mat1*2,{'a':1.0,'b':0.5})
+    A = numpy.array([[ 1.68294197, -1.68294197],[ 1.99498997, 1.68294197]])
+    B = numpy.array([[ 3.36588394, -3.36588394],[ 3.98997995, 3.36588394]])
+    numpy.testing.assert_allclose(E,A)
+    numpy.testing.assert_allclose(F,A)
+    numpy.testing.assert_allclose(G,A)
+    numpy.testing.assert_allclose(H,B)
+
+def test_dot():
+    list1 = make_expval_list()
+    mat1  = tq.QTensor(objective_list=list1, shape=(2,2))
+    E = tq.simulate(numpy.dot(mat1,mat1),{'a':1.0,'b':0.5})
+    F = numpy.array([[-0.13128967, -1.41614684], [ 1.67872618, -0.13128967]])
+    numpy.testing.assert_allclose(E,F)
+
+def test_grad():
+    list1 = make_expval_list()
+    mat1  = tq.QTensor(objective_list=list1, shape=(2,2))
+    mat2 = tq.grad(mat1,'a')
+    mat3 = tq.grad(mat2,'b')
+    E1 = tq.simulate(mat1,{'a':1.0,'b':0.5})
+    E2 = tq.simulate(mat2,{'a':1.0,'b':0.5})
+    E3 = tq.simulate(mat3,{'a':1.0,'b':0.5})
+    F1 = numpy.array([[0.84147098, -0.84147098],[ 0.99749499,0.84147098]])
+    F2 = numpy.array([[ 0.54030231, -0.54030231],[0.0707372, 0.54030231]])
+    F3 = numpy.array([[0.,0.],[-0.99749499, 0.]])
+    numpy.testing.assert_allclose(E1,F1)
+    numpy.testing.assert_allclose(E2,F2)
+    numpy.testing.assert_allclose(E3,F3)

--- a/tests/test_qtensor.py
+++ b/tests/test_qtensor.py
@@ -9,8 +9,8 @@ def make_expval_list():
 
     U3 = tq.gates.Ry(angle='b',target=0)
 
-    E1 = tq.ExpectationValue(H=H, U=U1) # result is 1
-    E2 = tq.ExpectationValue(H=H, U=U2) # result is -1
+    E1 = tq.ExpectationValue(H=H, U=U1)
+    E2 = tq.ExpectationValue(H=H, U=U2)
     E3 = tq.ExpectationValue(H=H, U=U1+U3)
     return [E1, E2, E3, E1]
 
@@ -20,14 +20,14 @@ def test_qtensor_with_numbers():
     mat1 = tq.QTensor(objective_list=list1,shape = [2,2])
     vec1 = tq.QTensor(objective_list=list2,shape = [2])
     res = tq.simulate(numpy.dot(mat1,vec1))
-    numpy.testing.assert_allclose(res,[2, 2.75])
+    numpy.testing.assert_allclose(res,[2, 2.75],atol=1e-05)
 
 def test_qtensor_with_objectives():
     list1 = make_expval_list()
     mat1  = tq.QTensor(objective_list=list1, shape=(2,2))
     E = tq.simulate(mat1, {'a':1.0,'b':0.5})
     F = numpy.array([[0.84147098, -0.84147098],[0.99749499, 0.84147098]])
-    numpy.testing.assert_allclose(E,F)
+    numpy.testing.assert_allclose(E,F,atol=1e-05)
 
 def test_apply():
     list1 = make_expval_list()
@@ -35,7 +35,7 @@ def test_apply():
     mat2 = mat1.apply(numpy.exp)
     E = tq.simulate(mat2, {'a':1.0,'b':0.5})
     F = numpy.array([[2.31977682, 0.43107595], [2.71148102, 2.31977682]])
-    numpy.testing.assert_allclose(E,F)
+    numpy.testing.assert_allclose(E,F,atol=1e-05)
 
 def test_count_expval():
     list1 = make_expval_list()
@@ -52,17 +52,17 @@ def test_add():
     H = tq.simulate(2*mat1+mat1*2,{'a':1.0,'b':0.5})
     A = numpy.array([[ 1.68294197, -1.68294197],[ 1.99498997, 1.68294197]])
     B = numpy.array([[ 3.36588394, -3.36588394],[ 3.98997995, 3.36588394]])
-    numpy.testing.assert_allclose(E,A)
-    numpy.testing.assert_allclose(F,A)
-    numpy.testing.assert_allclose(G,A)
-    numpy.testing.assert_allclose(H,B)
+    numpy.testing.assert_allclose(E,A,atol=1e-05)
+    numpy.testing.assert_allclose(F,A,atol=1e-05)
+    numpy.testing.assert_allclose(G,A,atol=1e-05)
+    numpy.testing.assert_allclose(H,B,atol=1e-05)
 
 def test_dot():
     list1 = make_expval_list()
     mat1  = tq.QTensor(objective_list=list1, shape=(2,2))
     E = tq.simulate(numpy.dot(mat1,mat1),{'a':1.0,'b':0.5})
     F = numpy.array([[-0.13128967, -1.41614684], [ 1.67872618, -0.13128967]])
-    numpy.testing.assert_allclose(E,F)
+    numpy.testing.assert_allclose(E,F,atol=1e-05)
 
 def test_grad():
     list1 = make_expval_list()
@@ -75,6 +75,6 @@ def test_grad():
     F1 = numpy.array([[0.84147098, -0.84147098],[ 0.99749499,0.84147098]])
     F2 = numpy.array([[ 0.54030231, -0.54030231],[0.0707372, 0.54030231]])
     F3 = numpy.array([[0.,0.],[-0.99749499, 0.]])
-    numpy.testing.assert_allclose(E1,F1)
-    numpy.testing.assert_allclose(E2,F2)
-    numpy.testing.assert_allclose(E3,F3)
+    numpy.testing.assert_allclose(E1,F1,atol=1e-05)
+    numpy.testing.assert_allclose(E2,F2,atol=1e-05)
+    numpy.testing.assert_allclose(E3,F3,atol=1e-05)

--- a/tests/test_qtensor.py
+++ b/tests/test_qtensor.py
@@ -1,0 +1,10 @@
+import tequila as tq
+import numpy
+
+def test_qtensor_with_numbers():
+    list1 = [0.5+tq.Objective(),1.5+tq.Objective(),0.75+tq.Objective(),2+tq.Objective()]
+    list2 = [1+tq.Objective(),1+tq.Objective()]
+    mat1 = tq.QTensor(objective_list=list1,shape = [2,2])
+    vec1 = tq.QTensor(objective_list=list2,shape = [2])
+    res = tq.simulate(numpy.dot(mat1,vec1))
+    assert res[0] == 2.


### PR DESCRIPTION
In this PR, I have added a new file `qtensor.py` which contains the class `QTensor`. This class was needed to ease the implementation of mathematical objects like vectors, matrices, and tensors. This class has been derived from `numpy.ndarray` and thus, all the linear algebraic operations that can be performed on an ndarray can be performed on a QTensor object. Besides, applying any function on a QTensor object, compiling, simulating, or taking the grad of a QTensor object can be done in the same way as is done for a tequila objective.
Apart from that, I have also added `test_qtensor.py` file which contains tests for this class. <br> 
For more details on the usage and implementation of QTensor, I have also added two notebooks in `tequila-tutorials`:<br>
1. Tutorial notebook: `QTensorTutorial.ipynb` - https://github.com/tequilahub/tequila-tutorials/blob/main/QTensorTutorial.ipynb
2. Implementation notebook: `QTensorImplementation.ipynb` - https://github.com/tequilahub/tequila-tutorials/blob/main/QTensorImplementation.ipynb
