### PR TITLE
fix heavy element formatting for periodictable

### DIFF
--- a/src/tequila/quantumchemistry/chemistry_tools.py
+++ b/src/tequila/quantumchemistry/chemistry_tools.py
@@ -153,10 +153,11 @@ class ParametersQC:
             return atom_numbers[name.lower()]
         try:
             import periodictable as pt
-            atom = name.lower()
+            atom = list(name.lower())
             atom[0] = atom[0].upper()
+            atom = ''.join(atom)
             element = pt.elements.symbol(atom)
-            return element.number()
+            return element.number
         except:
             raise TequilaException(
                 "can not assign atomic number to element {}\npip install periodictable will fix it".format(atom))


### PR DESCRIPTION
Heavy elements won't work using `periodictable` due to a small formatting issue. For example, even after  `pip install periodictable`, running, e.g.

```python
import tequila as tq

geomstring="Zn 0.0 0.0 0.0"
molecule = tq.Molecule(geometry=geomstring, frozen_core=True, basis_set='cc-pvdz', backend='pyscf')
```

will fail with

```
tequila.utils.exceptions.TequilaException: can not assign atomic number to element zn
pip install periodictable will fix it
```

The issue lies in https://github.com/tequilahub/tequila/blob/d09a1ad6f161ee5f5b65c5ed4c83286d9973c217/src/tequila/quantumchemistry/chemistry_tools.py#L157
because you will get a `TypeError: 'str' object does not support item assignment`. The proposed fix is to convert to a list, make the first element uppercase, and then rejoin to `str`.

There is also a small issue with the return in https://github.com/tequilahub/tequila/blob/d09a1ad6f161ee5f5b65c5ed4c83286d9973c217/src/tequila/quantumchemistry/chemistry_tools.py#L159

because `number` is a parameter, not a callable. See, for example, the `Element` code [here](https://github.com/pkienzle/periodictable/blob/4fb8068cc94a96704646e14ef2aebf939697e164/periodictable/core.py#L487-L506).