### PR TITLE
Update madness_interface.py

### DIFF
--- a/src/tequila/quantumchemistry/madness_interface.py
+++ b/src/tequila/quantumchemistry/madness_interface.py
@@ -617,8 +617,13 @@ class QuantumChemistryMadness(QuantumChemistryBase):
             n_pno = n_orbitals - n_pairs
 
         if maxrank is None:
-            maxrank = int(numpy.ceil(n_pno // n_pairs))
-
+            # need at least maxrank=1, otherwise no PNOs are computed
+            # this was a bug in <=v1.8.5 
+            maxrank = max(1,int(numpy.ceil(n_pno // n_pairs)))
+        
+        if maxrank<=0:
+            warnings.warn("maxrank={} in tequila madness backend! No PNOs will be computed. Set the value when initializing the Molecule as tq.Molecule(..., pno={\"maxrank\":1, ...})".format(maxrank), TequilaWarning)
+        
         data = {}
         if self.parameters.multiplicity != 1:
             raise TequilaMadnessException(

--- a/src/tequila/version.py
+++ b/src/tequila/version.py
@@ -1,2 +1,2 @@
-__version__ = "1.8.5"
+__version__ = "1.8.6"
 __author__ = "Jakob Kottmann and Sumner Alperin-Lea and Teresa Tamayo-Mendoza and Alba Cervera-Lierta and Cyrille Lavigne and Tzu-Ching Yen and Vladyslav Verteletskyi and Philipp Schleich and Abhinav Anand and Matthias Degroote and Skylar Chaney and Maha Kesibi and Naomi Grace Curnow and Brandon Solo and Georgios Tsilimigkounakis and Claudia Zendejas-Morales and Artur F Izmaylov and Alan Aspuru-Guzik ... "


### PR DESCRIPTION
fixing a bug that appears when n_pno is set manually and is smaller than the number of electron pairs. Example N2 with n_pno=3 (triple bond only). Maxrank was then set to zero. Prevent this from happening by forcing maxrank to be at least 1 when auto-assigned.