### PR TITLE
Fix NumPy float and int

### DIFF
--- a/src/tequila/apps/robustness/interval.py
+++ b/src/tequila/apps/robustness/interval.py
@@ -337,7 +337,7 @@ class GramianExpectationBound(RobustnessInterval):
         for eigvals, expec, variance in zip(self._pauligroups_eigenvalues, self._pauligroups_expectations,
                                             self._pauligroups_variances):
             min_eigval = min(eigvals)
-            expec_pos = np.clip(expec - min_eigval, 0, None, dtype=np.float)
+            expec_pos = np.clip(expec - min_eigval, 0, None, dtype=np.float64)
             bound += min_eigval + self._calc_lower_bound(expec_pos, variance, self.fidelity)
 
         return bound

--- a/src/tequila/hamiltonian/qubit_hamiltonian.py
+++ b/src/tequila/hamiltonian/qubit_hamiltonian.py
@@ -523,7 +523,7 @@ class QubitHamiltonian:
         hermitian = QubitHamiltonian.zero()
         anti_hermitian = QubitHamiltonian.zero()
         for k, v in self.qubit_operator.terms.items():
-            hermitian.qubit_operator.terms[k] = np.float(v.real)
+            hermitian.qubit_operator.terms[k] = np.float64(v.real)
             anti_hermitian.qubit_operator.terms[k] = 1.j * v.imag
 
         return hermitian.simplify(), anti_hermitian.simplify()

--- a/src/tequila/simulators/simulator_qibo.py
+++ b/src/tequila/simulators/simulator_qibo.py
@@ -355,7 +355,7 @@ class BackendCircuitQibo(BackendCircuit):
         """
         n_qubits = max(self.highest_qubit + 1, self.n_qubits, self.abstract_circuit.max_qubit() + 1)
         if initial_state is not None:
-            if isinstance(initial_state, int) or isinstance(initial_state,np.int):
+            if isinstance(initial_state, int) or isinstance(initial_state, np.int64):
                 wave = QubitWaveFunction.from_int(i=initial_state, n_qubits=n_qubits)
             elif isinstance(initial_state, str):
                 wave = QubitWaveFunction.from_string(string=initial_state).to_array()


### PR DESCRIPTION
`np.float` and `np.int` does not exist in NumPy anymore.

Code changed to use `np.float64` and `np.int64`.