### PR TITLE
Fix NumPy float and int

### DIFF
--- a/src/tequila/apps/robustness/interval.py
+++ b/src/tequila/apps/robustness/interval.py
@@ -190,7 +190,7 @@ class SDPInterval(RobustnessInterval):
                 pauli_lower_bound = pauli_upper_bound = 1.0
             else:
                 expec_normalized = np.clip(2 * (p_expec - min_eigval) / (max_eigval - min_eigval) - 1, -1, 1,
-                                           dtype=np.float64)
+                                           dtype=float)
 
                 pauli_lower_bound = (max_eigval - min_eigval) / 2.0 * (
                         1 + self._calc_lower_bound(expec_normalized, self.fidelity)) + min_eigval
@@ -337,7 +337,7 @@ class GramianExpectationBound(RobustnessInterval):
         for eigvals, expec, variance in zip(self._pauligroups_eigenvalues, self._pauligroups_expectations,
                                             self._pauligroups_variances):
             min_eigval = min(eigvals)
-            expec_pos = np.clip(expec - min_eigval, 0, None, dtype=np.float64)
+            expec_pos = np.clip(expec - min_eigval, 0, None, dtype=float)
             bound += min_eigval + self._calc_lower_bound(expec_pos, variance, self.fidelity)
 
         return bound

--- a/src/tequila/apps/robustness/interval.py
+++ b/src/tequila/apps/robustness/interval.py
@@ -337,7 +337,7 @@ class GramianExpectationBound(RobustnessInterval):
         for eigvals, expec, variance in zip(self._pauligroups_eigenvalues, self._pauligroups_expectations,
                                             self._pauligroups_variances):
             min_eigval = min(eigvals)
-            expec_pos = np.clip(expec - min_eigval, 0, None, dtype=np.float)
+            expec_pos = np.clip(expec - min_eigval, 0, None, dtype=np.float64)
             bound += min_eigval + self._calc_lower_bound(expec_pos, variance, self.fidelity)
 
         return bound

--- a/src/tequila/hamiltonian/qubit_hamiltonian.py
+++ b/src/tequila/hamiltonian/qubit_hamiltonian.py
@@ -523,7 +523,7 @@ class QubitHamiltonian:
         hermitian = QubitHamiltonian.zero()
         anti_hermitian = QubitHamiltonian.zero()
         for k, v in self.qubit_operator.terms.items():
-            hermitian.qubit_operator.terms[k] = np.float64(v.real)
+            hermitian.qubit_operator.terms[k] = v.real
             anti_hermitian.qubit_operator.terms[k] = 1.j * v.imag
 
         return hermitian.simplify(), anti_hermitian.simplify()

--- a/src/tequila/hamiltonian/qubit_hamiltonian.py
+++ b/src/tequila/hamiltonian/qubit_hamiltonian.py
@@ -523,7 +523,7 @@ class QubitHamiltonian:
         hermitian = QubitHamiltonian.zero()
         anti_hermitian = QubitHamiltonian.zero()
         for k, v in self.qubit_operator.terms.items():
-            hermitian.qubit_operator.terms[k] = np.float(v.real)
+            hermitian.qubit_operator.terms[k] = np.float64(v.real)
             anti_hermitian.qubit_operator.terms[k] = 1.j * v.imag
 
         return hermitian.simplify(), anti_hermitian.simplify()

--- a/src/tequila/ml/interface_torch.py
+++ b/src/tequila/ml/interface_torch.py
@@ -128,7 +128,7 @@ def get_torch_function(objective: Objective, compile_args: dict = None, input_va
                     g_keys = [j for j in grads.keys()]
                     probe = grads[g_keys[0]]  # first entry will tell us number of output
                     dims = len(g_keys), len(probe)
-                    arr = np.empty(dims, dtype=np.float)
+                    arr = np.empty(dims, dtype=np.float64)
                     for j, key in enumerate(g_keys):
                         line = grads[key]
                         for k, ob in enumerate(line):

--- a/src/tequila/ml/interface_torch.py
+++ b/src/tequila/ml/interface_torch.py
@@ -128,7 +128,7 @@ def get_torch_function(objective: Objective, compile_args: dict = None, input_va
                     g_keys = [j for j in grads.keys()]
                     probe = grads[g_keys[0]]  # first entry will tell us number of output
                     dims = len(g_keys), len(probe)
-                    arr = np.empty(dims, dtype=np.float64)
+                    arr = np.empty(dims, dtype=float)
                     for j, key in enumerate(g_keys):
                         line = grads[key]
                         for k, ob in enumerate(line):

--- a/src/tequila/simulators/simulator_qibo.py
+++ b/src/tequila/simulators/simulator_qibo.py
@@ -355,7 +355,7 @@ class BackendCircuitQibo(BackendCircuit):
         """
         n_qubits = max(self.highest_qubit + 1, self.n_qubits, self.abstract_circuit.max_qubit() + 1)
         if initial_state is not None:
-            if isinstance(initial_state, int) or isinstance(initial_state, np.int64):
+            if isinstance(initial_state, (int, np.int64)):
                 wave = QubitWaveFunction.from_int(i=initial_state, n_qubits=n_qubits)
             elif isinstance(initial_state, str):
                 wave = QubitWaveFunction.from_string(string=initial_state).to_array()

--- a/src/tequila/simulators/simulator_qibo.py
+++ b/src/tequila/simulators/simulator_qibo.py
@@ -355,7 +355,7 @@ class BackendCircuitQibo(BackendCircuit):
         """
         n_qubits = max(self.highest_qubit + 1, self.n_qubits, self.abstract_circuit.max_qubit() + 1)
         if initial_state is not None:
-            if isinstance(initial_state, int) or isinstance(initial_state,np.int):
+            if isinstance(initial_state, int) or isinstance(initial_state, np.int64):
                 wave = QubitWaveFunction.from_int(i=initial_state, n_qubits=n_qubits)
             elif isinstance(initial_state, str):
                 wave = QubitWaveFunction.from_string(string=initial_state).to_array()


### PR DESCRIPTION
`np.float` and `np.int` does not exist in NumPy anymore.

Code changed to use `np.float64` and `np.int64`.