### PR TITLE
F3 circuit optimizations

### DIFF
--- a/src/tequila/grouping/fermionic_methods.py
+++ b/src/tequila/grouping/fermionic_methods.py
@@ -214,12 +214,15 @@ def do_svd(h_ferm, n_elec):
     return all_uops, cartan_obt, cartan_tbts, meas_alloc
 
 
-def get_fermion_wise(H, U):
+def get_fermion_wise(H, U, qubit_list = []):
+    '''
+    Return z_form and orbital rotations over qubits at qubit_list
+    '''
 
     H = ferm.cartan_tbt_to_ferm(H, spin_orb = True)
     z_form = QubitHamiltonian(jordan_wigner(H))
 
-    circuit = ferm.get_orb_rot(U, tol = 1e-12)
+    circuit = ferm.get_orb_rot(U, qubit_list=qubit_list, tol = 1e-12)
     return [z_form, circuit]
 
 def get_init_ops(h_ferm, mol_name, calc_type, spin_orb, save=True):


### PR DESCRIPTION
Currently the F3 circuit has O(N^2) depth and circuit gate count. Added in this commit 
- linear depth scaling via reordering elimination of matrix entries as elucidated here: http://arxiv.org/abs/2106.13839
- Fixed gate filtering to remove redundant gates, few parameter checks.


Further reduction can be achieved as follows:
A general mean-field unitary U is decomposed into givens rotations, determined by eliminating off-diagonal elements in the matrix representation of U. For N orbitals, we have $N(N-1)/2$ such eliminations/Givens rotations for a N orbital system. Each givens rotation is between adjacent qubits only and are efficient in terms of gates.

For Hamiltonians over 2N spin-orbitals, the Unitaries U constructed for F3 fragments, except the first one body fragment currently are spin-restricted by default. This means that the matrix representation of U has a block-diagonal form, i.e., $U = U_u * U_d$ can be written as a product of mean-field unitaries over spin up/down sectors separately. But in order to implement $U_u$ and $U_d$ efficiently by givens rotations over adjacent qubits, we would require either the fermion ordering to be uudd and not udud (default) (or) a different modified jordan-wigner. The F3 routines currently can be directly adapted by simply relabelling the final outputted tensors and unitaries, but this reordering would require the user to use state-preparation with a different qubit ordering/mapping, and start with the Hamiltonian with fermions/spins reordered.

I'm not sure how to proceed with adding this as tequila mostly uses spin udud as in openfermion and might mean changes up-stream (it's not clear what parts of the workflow would this affect).