### PR TITLE
Refactor `GeneralizedRotation` to generators with (possible) nullspace.

### DIFF
--- a/src/tequila/circuit/_gates_impl.py
+++ b/src/tequila/circuit/_gates_impl.py
@@ -379,6 +379,10 @@ class GeneralizedRotationImpl(DifferentiableGateImpl):
     def __init__(self, angle, generator, p0=None, control=None, eigenvalues_magnitude=0.5, steps=1, name="GenRot", assume_real=False):
         super().__init__(eigenvalues_magnitude=eigenvalues_magnitude, generator=generator, assume_real=assume_real, name=name, parameter=angle, target=self.extract_targets(generator), control=control)
         self.steps = steps
+        if control is not None:
+            # augment p0 for control qubits
+            # Qp = 1/2(1+Z) = |0><0|
+            p0 = p0*paulis.Qp(control)
         self.p0 = p0
         
     def shifted_gates(self):

--- a/src/tequila/circuit/_gates_impl.py
+++ b/src/tequila/circuit/_gates_impl.py
@@ -381,7 +381,7 @@ class GeneralizedRotationImpl(DifferentiableGateImpl):
             target = self.extract_targets(generator)
         super().__init__(eigenvalues_magnitude=eigenvalues_magnitude, generator=generator, assume_real=assume_real, name=name, parameter=angle, target=target, control=control)
         self.steps = steps
-        if control is not None:
+        if control is None and p0 is not None:
             # augment p0 for control qubits
             # Qp = 1/2(1+Z) = |0><0|
             p0 = p0*paulis.Qp(control)

--- a/src/tequila/circuit/_gates_impl.py
+++ b/src/tequila/circuit/_gates_impl.py
@@ -406,7 +406,7 @@ class GeneralizedRotationImpl(DifferentiableGateImpl):
         Um1._parameter = self.parameter-s
         Um2 = GeneralizedRotationImpl(angle=-s, generator=self.p0, eigenvalues_magnitude=r) # controls are in p0
 
-        return [(2.0 * r, [Up1,  Up2]), (-2.0 * r, [Um1 + Um2])]
+        return [(2.0 * r, [Up1,  Up2]), (-2.0 * r, [Um1, Um2])]
         
 class ExponentialPauliGateImpl(DifferentiableGateImpl):
     """

--- a/src/tequila/circuit/_gates_impl.py
+++ b/src/tequila/circuit/_gates_impl.py
@@ -376,8 +376,10 @@ class GeneralizedRotationImpl(DifferentiableGateImpl):
             targets += [k for k in ps.keys()]
         return tuple(set(targets))
 
-    def __init__(self, angle, generator, p0=None, control=None, eigenvalues_magnitude=0.5, steps=1, name="GenRot", assume_real=False):
-        super().__init__(eigenvalues_magnitude=eigenvalues_magnitude, generator=generator, assume_real=assume_real, name=name, parameter=angle, target=self.extract_targets(generator), control=control)
+    def __init__(self, angle, generator, p0=None, control=None, target=None, eigenvalues_magnitude=0.5, steps=1, name="GenRot", assume_real=False):
+        if target == None:
+            target = self.extract_targets(generator)
+        super().__init__(eigenvalues_magnitude=eigenvalues_magnitude, generator=generator, assume_real=assume_real, name=name, parameter=angle, target=target, control=control)
         self.steps = steps
         if control is not None:
             # augment p0 for control qubits

--- a/src/tequila/circuit/gates.py
+++ b/src/tequila/circuit/gates.py
@@ -1052,7 +1052,7 @@ class QubitExcitationImpl(impl.GeneralizedRotationImpl):
             assert generator is not None
             assert p0 is not None
         
-        super().__init__(name="QubitExcitation", angle=angle, generator=generator, p0=p0, control=control, assume_real=assume_real, steps=1)
+        super().__init__(name="QubitExcitation", angle=angle, generator=generator, target=target, p0=p0, control=control, assume_real=assume_real, steps=1)
         
         if compile_options is None:
             self.compile_options = "optimize"

--- a/src/tequila/circuit/gates.py
+++ b/src/tequila/circuit/gates.py
@@ -361,6 +361,9 @@ def Rp(paulistring: typing.Union[PauliString, str], angle, control: typing.Union
     return ExpPauli(paulistring=paulistring, angle=angle, control=control, *args, **kwargs)
 
 
+def GenRot(*args, **kwargs):
+    return GeneralizedRotation(*args, **kwargs)
+
 def GeneralizedRotation(angle: typing.Union[typing.List[typing.Hashable], typing.List[numbers.Real]],
                         generator: QubitHamiltonian,
                         control: typing.Union[list, int] = None,
@@ -393,6 +396,8 @@ def GeneralizedRotation(angle: typing.Union[typing.List[typing.Hashable], typing
         list of control qubits
     eigenvalues_magnitude
         magnitude of eigenvalues, in most papers referred to as "r" (default 0.5)
+    p0
+        possible nullspace projector (if the rotation is happens in Q = 1-P0). See arxiv:2011.05938
     steps
         possible Trotterization steps (default 1)
 

--- a/src/tequila/circuit/gates.py
+++ b/src/tequila/circuit/gates.py
@@ -364,7 +364,7 @@ def Rp(paulistring: typing.Union[PauliString, str], angle, control: typing.Union
 def GeneralizedRotation(angle: typing.Union[typing.List[typing.Hashable], typing.List[numbers.Real]],
                         generator: QubitHamiltonian,
                         control: typing.Union[list, int] = None,
-                        eigenvalues_magnitude: float = 0.5,
+                        eigenvalues_magnitude: float = 0.5, p0=None,
                         steps: int = 1, assume_real=False) -> QCircuit:
     """
 
@@ -403,7 +403,7 @@ def GeneralizedRotation(angle: typing.Union[typing.List[typing.Hashable], typing
 
     return QCircuit.wrap_gate(
         impl.GeneralizedRotationImpl(angle=assign_variable(angle), generator=generator, control=control,
-                                eigenvalues_magnitude=eigenvalues_magnitude, steps=steps, assume_real=assume_real))
+                                eigenvalues_magnitude=eigenvalues_magnitude, steps=steps, assume_real=assume_real, p0=p0))
 
 
 

--- a/src/tequila/circuit/gates.py
+++ b/src/tequila/circuit/gates.py
@@ -1062,18 +1062,9 @@ class QubitExcitationImpl(impl.GeneralizedRotationImpl):
             self.compile_options = compile_options
 
     def map_qubits(self, qubit_map: dict):
-        mapped_generator = self.generator.map_qubits(qubit_map=qubit_map)
-        mapped_p0 = self.p0.map_qubits(qubit_map=qubit_map)
-        mapped_control = self.control
-        if mapped_control is not None:
-            mapped_control=tuple([qubit_map[i] for i in self.control])
-        result = copy.deepcopy(self)
-        result.generator=mapped_generator
-        result.p0 = mapped_p0
-        result._target = tuple([qubit_map[x] for x in self.target])
-        result._control = mapped_control
-        result.finalize()
-        return result
+        mapped = super().map_qubits(qubit_map)
+        mapped.p0 = self.p0.map_qubits(qubit_map=qubit_map)
+        return mapped
 
     def compile(self, exponential_pauli=False, *args, **kwargs):
         # optimized compiling for single and double qubit excitaitons following arxiv:2005.14475

--- a/src/tequila/circuit/gates.py
+++ b/src/tequila/circuit/gates.py
@@ -1051,11 +1051,6 @@ class QubitExcitationImpl(impl.GeneralizedRotationImpl):
         else:
             assert generator is not None
             assert p0 is not None
-
-        if control is not None:
-            # augment p0 for control qubits
-            # Qp = 1/2(1+Z) = |0><0|
-            p0 = p0*paulis.Qp(control)
         
         super().__init__(name="QubitExcitation", angle=angle, generator=generator, p0=p0, control=control, assume_real=assume_real, steps=1)
         

--- a/src/tequila/hamiltonian/paulis.py
+++ b/src/tequila/hamiltonian/paulis.py
@@ -209,7 +209,7 @@ def Sm(qubit) -> QubitHamiltonian:
     Initialize
 
     .. math::
-        \\frac{1}{2} \\left( \\sigma_x + i \\sigma_y \\right)
+        \\frac{1}{2} \\left( \\sigma_x - i \\sigma_y \\right)
 
     Parameters
     ----------


### PR DESCRIPTION
Hi Jakob,

Following our discussion about the `GeneralizedRotation` gate, I have transferred the `shifted_gates` functionality from `QubitExcitation` to `GeneralizedRotation`. This modification allows the `GeneralizedRotation` method to accept generators that do not necessarily have only two eigenvalues of +-r.