### PR TITLE
Simulation performance improvements

### DIFF
--- a/src/tequila/utils/bitstrings.py
+++ b/src/tequila/utils/bitstrings.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import List
 from functools import total_ordering
+from math import ceil, log2
 
 
 class BitNumbering(Enum):
@@ -35,7 +36,7 @@ class BitString:
 
     def update_nbits(self):
         current = self.nbits
-        min_needed = self._value.bit_length()
+        min_needed = ceil(log2(self._value + 1))
         self._nbits = max(current, min_needed)
         return self
 
@@ -177,15 +178,23 @@ class BitStringLSB(BitString):
         return BitNumbering.LSB
 
 
+def _reverse_int_bits(x: int, nbits: int) -> int:
+    if nbits is None:
+        nbits = x.bit_length()
+    assert nbits <= 32
+
+    x = ((x & 0x55555555) << 1) | ((x & 0xAAAAAAAA) >> 1)
+    x = ((x & 0x33333333) << 2) | ((x & 0xCCCCCCCC) >> 2)
+    x = ((x & 0x0F0F0F0F) << 4) | ((x & 0xF0F0F0F0) >> 4)
+    x = ((x & 0x00FF00FF) << 8) | ((x & 0xFF00FF00) >> 8)
+    x = ((x & 0x0000FFFF) << 16) | ((x & 0xFFFF0000) >> 16)
+    return x >> (32 - nbits)
+
+
 def initialize_bitstring(integer: int, nbits: int = None, numbering_in: BitNumbering = BitNumbering.MSB,
                          numbering_out: BitNumbering = BitNumbering.MSB):
+    integer = _reverse_int_bits(integer, nbits) if numbering_in != numbering_out else integer
     if numbering_out == BitNumbering.MSB:
-        if numbering_in == BitNumbering.MSB:
-            return BitString.from_int(integer=integer, nbits=nbits)
-        else:
-            return BitString.from_binary(binary=BitStringLSB.from_int(integer=integer, nbits=nbits).binary, nbits=nbits)
+        return BitString.from_int(integer=integer, nbits=nbits)
     else:
-        if numbering_in == BitNumbering.LSB:
-            return BitStringLSB.from_int(integer=integer, nbits=nbits)
-        else:
-            return BitStringLSB.from_binary(binary=BitString.from_int(integer=integer, nbits=nbits).binary, nbits=nbits)
+        return BitStringLSB.from_int(integer=integer, nbits=nbits)

--- a/src/tequila/utils/bitstrings.py
+++ b/src/tequila/utils/bitstrings.py
@@ -35,7 +35,7 @@ class BitString:
 
     def update_nbits(self):
         current = self.nbits
-        min_needed = len(format(self._value, 'b'))
+        min_needed = self._value.bit_length()
         self._nbits = max(current, min_needed)
         return self
 
@@ -179,13 +179,13 @@ class BitStringLSB(BitString):
 
 def initialize_bitstring(integer: int, nbits: int = None, numbering_in: BitNumbering = BitNumbering.MSB,
                          numbering_out: BitNumbering = BitNumbering.MSB):
-    if numbering_in == BitNumbering.MSB:
-        if numbering_out == BitNumbering.MSB:
+    if numbering_out == BitNumbering.MSB:
+        if numbering_in == BitNumbering.MSB:
             return BitString.from_int(integer=integer, nbits=nbits)
         else:
             return BitString.from_binary(binary=BitStringLSB.from_int(integer=integer, nbits=nbits).binary, nbits=nbits)
     else:
-        if numbering_out == BitNumbering.LSB:
+        if numbering_in == BitNumbering.LSB:
             return BitStringLSB.from_int(integer=integer, nbits=nbits)
         else:
             return BitStringLSB.from_binary(binary=BitString.from_int(integer=integer, nbits=nbits).binary, nbits=nbits)

--- a/src/tequila/wavefunction/qubit_wavefunction.py
+++ b/src/tequila/wavefunction/qubit_wavefunction.py
@@ -145,8 +145,8 @@ class QubitWaveFunction:
         maxkey = len(arr) - 1
         maxbit = initialize_bitstring(integer=maxkey, numbering_in=numbering, numbering_out=cls.numbering).nbits
         for ii, v in enumerate(arr):
-            i = initialize_bitstring(integer=ii, nbits=maxbit, numbering_in=numbering, numbering_out=cls.numbering)
-            if not numpy.isclose(abs(v), 0.0, atol=threshold):
+            if abs(v) > threshold:
+                i = initialize_bitstring(integer=ii, nbits=maxbit, numbering_in=numbering, numbering_out=cls.numbering)
                 key = i if keymap is None else keymap(i)
                 state[key] = v
         result = QubitWaveFunction(state, n_qubits=n_qubits)

--- a/src/tequila/wavefunction/qubit_wavefunction.py
+++ b/src/tequila/wavefunction/qubit_wavefunction.py
@@ -151,12 +151,6 @@ class QubitWaveFunction:
                 state[key] = v
         result = QubitWaveFunction(state, n_qubits=n_qubits)
 
-        if cls.numbering != numbering:
-            if cls.numbering == BitNumbering.MSB:
-                result.apply_keymap(keymap=KeyMapLSB2MSB())
-            else:
-                result.apply_keymap(keymap=KeyMapMSB2LSB())
-
         return result
 
     @classmethod


### PR DESCRIPTION
While investigating why the Qulacs backend does not seem to use multiple threads in my code, I noticed that very little time is spent in the actual simulation.

For testing, I used the Quantum Fourier Transform. By running either just a QFT, or a QFT and then an inverse QFT, we can make the resulting wavefunction dense or sparse, which is important for testing the performance.

<details>
<summary>Code</summary>

```python
import tequila as tq
from math import pi
import time

SIZE = 20

def qft(size: int, inverse: bool = False) -> tq.QCircuit():
    U = tq.QCircuit()
    for i in range(size):
        U += tq.gates.H(target=i)
        for j in range(size - i - 1):
            U += tq.gates.Phase(target=i + j + 1, angle=(-1 if inverse else 1) * pi / 2 ** (j + 2))
            U += tq.gates.CRz(target=i, control=i + j + 1, angle=(-1 if inverse else 1) * pi / 2 ** (j + 1))
    return U

U = qft(SIZE)
V = qft(SIZE) + qft(SIZE, inverse=True)

start = time.time()
wfn = tq.simulate(U, backend="qulacs")
print(f"QFT time: {time.time() - start} s")

start = time.time()
wfn = tq.simulate(V, backend="qulacs")
print(f"QFT + inverse QFT time: {time.time() - start} s")
```

</details>

Running this code on the `devel` branch takes ~160 seconds for the normal QFT and ~20 seconds for the combined QFT and inverse QFT on my machine. Note that the second one is much faster even though the simulated circuit is twice as large, this is because the result is a sparse wavefunction.
When measuring the time of `self.circuit.update_quantum_state(state)` in `do_simulate` in `simulator_qulacs.py` (which I believe is the actual simulation), it's only ~0.17s / ~0.28s (QFT / QFT + inverse), so there is a lot of room for speedups.
All the times here are simple measurements of single runs, and not proper benchmarks, but the differences are so large that it shouldn't matter if the numbers are inaccurate.

I made four commits which speed this up:

1. For a dense wavefunction, a lot of time is spent in the `apply_keymap` function in `simulate`. This doesn't seem necessary when all qubits are active, since then the mapping has no effect. So I added a check that skips the keymap entirely in that case, reducing the runtime to ~24s / ~20s.

2. The `numpy.isclose` call in `from_array` in `qubit_wavefunction.py` is expensive, likely because it checks for edge cases (infinity, nan) and because it can handle arrays. Assuming we simply want to skip values close to zero, this can be done much faster using a simple comparison.
Also, we only need to create the index bitstring when we actually want to set the value, so moving it inside the if clause saves a lot of time for sparse wavefunctions. These two changes reduce the runtime to ~6s / ~0.7s.

3. Still in the `from_array` function, if the numbering of the array doesn't match the numbering of the wavefunction, a keymap is applied to adjust it. This should not be necessary because the `initialize_bitstring` function should already return the correct type of bitstring. However currently the returned type depends on the `numbering_in` parameter, changing it to the `numbering_out` parameter allows removing the keymap and reduces the time to ~3.7s / ~0.6s.

4. Reversing the bits in a bitstring is currently done by converting the integer to a binary string, reversing the characters, and converting them back to an integer. This is inefficient and can be replaced with a [function that uses bit operations](https://stackoverflow.com/a/20918545). An interpretation of this code is that each line flips a bit in the position of each bit, so when all position bits are flipped, the position p is moved to 31 - p. This assumes the integer has exactly 32 bit, so if it has less, this adds zeros which we can get rid of with a bitshift.
Another small optimization is to calculate the logarithm to get the bitstring length, instead of converting to a binary string and counting (the integer `bit_length()` method can't be used because some code passes Numpy ints). Together, this reduces the runtime to ~2.5s / ~0.6s.

In total, the speedup is ~60x / ~30x for the script above, but is likely much less for other code. I have not tested if these speedups transfer to other backends. Further improvements are definitely possible, but I think I have covered a good amount of the low hanging fruit.