### PR TITLE
Deepcopy gates in `__iadd__` of `QCircuit`

### DIFF
--- a/src/tequila/circuit/circuit.py
+++ b/src/tequila/circuit/circuit.py
@@ -386,7 +386,7 @@ class QCircuit():
         for k, v in other._parameter_map.items():
             self._parameter_map[k] += [(x[0] + offset, x[1]) for x in v]
 
-        self._gates += other.gates
+        self._gates += copy.deepcopy(other.gates)
         self._min_n_qubits = max(self._min_n_qubits, other._min_n_qubits)
 
         return self


### PR DESCRIPTION
Currently the `__iadd__` function in `QCircuit` directly appends gates without copying. This means that when adding the same circuit twice, the same gate instances are added twice, instead of two copies.
This leads to unexpected problems, e.g. the following code doesn't work:

```python
import tequila as tq

U = tq.QCircuit()
gate = tq.gates.X(target=0)
U += gate
U += gate
U.add_controls(control=1)
```

This is because `add_controls` tries to add a control to the gate twice, but during the second time fails because the gate already has the control.

Interestingly, since `__add__` is implemented differently, this works:

```python
import tequila as tq

U = tq.QCircuit()
gate = tq.gates.X(target=0)
U = U + gate
U = U + gate
U.add_controls(control=1)
```

I'm not sure what the intended behavior is, but my example can be fixed by appending a deepcopy of the gates instead.