### PR TITLE
Fix current Qiskit versions

### DIFF
--- a/.github/workflows/ci_backends.yml
+++ b/.github/workflows/ci_backends.yml
@@ -32,7 +32,7 @@ jobs:
             # myqlm does not work in python3.7
             pip install "cirq" "qiskit>=0.30" "qulacs" "qibo==0.1.1"
         elif [ $ver -eq 8 ]; then
-            pip install "cirq" "qiskit>=0.30" "qulacs" "qibo==0.1.1" "myqlm" "cirq-google"
+            pip install "cirq" "qiskit" "qulacs" "qibo==0.1.1" "myqlm" "cirq-google"
         fi
         pip install -e .
     - name: Lint with flake8

--- a/README.md
+++ b/README.md
@@ -342,12 +342,7 @@ You can avoid it by downgrading cirq and openfermion
 ```bash
 pip install --upgrade "openfermion<=1.0.0"
 pip install --upgrade "cirq<=0.9.1"
-```  
-
-
-## Qiskit backend
-Qiskit version 0.25 is not yet supported.
-`pip install --upgrade qiskit<0.25` fixes potential issues. If not: Please let us know.
+```
 
 ## Circuit drawing
 Standard graphical circuit representation within a Jupyter environment is often done using `tq.draw`.

--- a/src/tequila/utils/bitstrings.py
+++ b/src/tequila/utils/bitstrings.py
@@ -178,7 +178,7 @@ class BitStringLSB(BitString):
         return BitNumbering.LSB
 
 
-def _reverse_int_bits(x: int, nbits: int) -> int:
+def reverse_int_bits(x: int, nbits: int) -> int:
     if nbits is None:
         nbits = x.bit_length()
     assert nbits <= 32
@@ -193,7 +193,7 @@ def _reverse_int_bits(x: int, nbits: int) -> int:
 
 def initialize_bitstring(integer: int, nbits: int = None, numbering_in: BitNumbering = BitNumbering.MSB,
                          numbering_out: BitNumbering = BitNumbering.MSB):
-    integer = _reverse_int_bits(integer, nbits) if numbering_in != numbering_out else integer
+    integer = reverse_int_bits(integer, nbits) if numbering_in != numbering_out else integer
     if numbering_out == BitNumbering.MSB:
         return BitString.from_int(integer=integer, nbits=nbits)
     else:


### PR DESCRIPTION
This is an attempt to update the `simulator_qiskit` code to be compatible with the latest version of Qiskit and Qiskit Aer. I likely did not catch everything, but basic calls to `tq.simulate()` should work.

Using this requires the packages `qiskit`, `qiskit-aer` and `qiskit-ibm-runtime`.

TODO: FakeProvider does not seem to exist anymore, see https://github.com/Qiskit/qiskit/pull/11376, and I wasn't sure what exactly it is used for, so I just commented it out for now.

References for some of the changes I made:
- `bind_parameters` -> `assign_parameters`: https://github.com/Qiskit/qiskit/issues/7057
- `qiskit.providers.ibmq` -> `qiskit_ibm_runtime`: READMEs in https://github.com/Qiskit/qiskit-ibmq-provider and https://github.com/Qiskit/qiskit-ibm-provider
- `qiskit.test.mock` -> `qiskit.providers.fake_provider`: https://github.com/Qiskit/qiskit/issues/7738
