### PR TITLE
Add Qiskit GPU simulator

### DIFF
--- a/.github/workflows/ci_backends.yml
+++ b/.github/workflows/ci_backends.yml
@@ -32,7 +32,7 @@ jobs:
             # myqlm does not work in python3.7
             pip install "cirq" "qiskit>=0.30" "qulacs" "qibo==0.1.1"
         elif [ $ver -eq 8 ]; then
-            pip install "cirq" "qiskit>=0.30" "qulacs" "qibo==0.1.1" "myqlm" "cirq-google"
+            pip install "cirq" "qiskit" "qulacs" "qibo==0.1.1" "myqlm" "cirq-google"
         fi
         pip install -e .
     - name: Lint with flake8

--- a/README.md
+++ b/README.md
@@ -342,12 +342,7 @@ You can avoid it by downgrading cirq and openfermion
 ```bash
 pip install --upgrade "openfermion<=1.0.0"
 pip install --upgrade "cirq<=0.9.1"
-```  
-
-
-## Qiskit backend
-Qiskit version 0.25 is not yet supported.
-`pip install --upgrade qiskit<0.25` fixes potential issues. If not: Please let us know.
+```
 
 ## Circuit drawing
 Standard graphical circuit representation within a Jupyter environment is often done using `tq.draw`.

--- a/src/tequila/simulators/simulator_api.py
+++ b/src/tequila/simulators/simulator_api.py
@@ -10,8 +10,8 @@ from tequila.utils.exceptions import TequilaException, TequilaWarning
 from tequila.simulators.simulator_base import BackendCircuit, BackendExpectationValue
 from tequila.circuit.noise import NoiseModel
 
-SUPPORTED_BACKENDS = ["qulacs_gpu", "qulacs",'qibo', "qiskit", "cirq", "pyquil", "symbolic", "qlm"]
-SUPPORTED_NOISE_BACKENDS = ["qiskit", 'cirq', 'pyquil'] # qulacs removed in v.1.9
+SUPPORTED_BACKENDS = ["qulacs", "qulacs_gpu", "qibo", "qiskit", "qiskit_gpu", "cirq", "pyquil", "symbolic", "qlm"]
+SUPPORTED_NOISE_BACKENDS = ["qiskit", "qiskit_gpu", "cirq", "pyquil"]  # qulacs removed in v.1.9
 BackendTypes = namedtuple('BackendTypes', 'CircType ExpValueType')
 INSTALLED_SIMULATORS = {}
 INSTALLED_SAMPLERS = {}
@@ -42,6 +42,19 @@ try:
 except ImportError:
     HAS_QISKIT = False
     HAS_QISKIT_NOISE = False
+
+try:
+    pkg_resources.require("qiskit-aer-gpu")
+    from tequila.simulators.simulator_qiskit_gpu import BackendCircuitQiskitGpu, BackendExpectationValueQiskitGpu
+    HAS_QISKIT_GPU = True
+    INSTALLED_SIMULATORS["qiskit_gpu"] = BackendTypes(BackendCircuitQiskitGpu, BackendExpectationValueQiskitGpu)
+    INSTALLED_SAMPLERS["qiskit_gpu"] = BackendTypes(BackendCircuitQiskitGpu, BackendExpectationValueQiskitGpu)
+    from tequila.simulators.simulator_qiskit_gpu import HAS_NOISE as HAS_QISKIT_GPU_NOISE
+    if HAS_QISKIT_GPU_NOISE:
+        INSTALLED_NOISE_SAMPLERS["qiskit_gpu"] = BackendTypes(BackendCircuitQiskitGpu, BackendExpectationValueQiskitGpu)
+except (ImportError, DistributionNotFound):
+    HAS_QISKIT_GPU = False
+    HAS_QISKIT_GPU_NOISE = False
 
 HAS_QIBO = True
 try:
@@ -82,8 +95,8 @@ except (ImportError, DistributionNotFound):
     HAS_QULACS = False
 
 try:
-    pkg_resources.require("qulacs-gpu")
-    import qulacs
+    # pkg_resources.require("qulacs-gpu")
+    from qulacs import QuantumStateGpu
     from tequila.simulators.simulator_qulacs_gpu import BackendCircuitQulacsGpu, BackendExpectationValueQulacsGpu
 
     HAS_QULACS_GPU = True

--- a/src/tequila/simulators/simulator_qiskit_gpu.py
+++ b/src/tequila/simulators/simulator_qiskit_gpu.py
@@ -1,0 +1,9 @@
+from tequila.simulators.simulator_qiskit import BackendCircuitQiskit, BackendExpectationValueQiskit
+
+
+class BackendCircuitQiskitGpu(BackendCircuitQiskit):
+    STATEVECTOR_DEVICE_NAME = "aer_simulator_statevector_gpu"
+
+
+class BackendExpectationValueQiskitGpu(BackendExpectationValueQiskit):
+    BackendCircuitType = BackendCircuitQiskitGpu

--- a/src/tequila/utils/bitstrings.py
+++ b/src/tequila/utils/bitstrings.py
@@ -178,7 +178,7 @@ class BitStringLSB(BitString):
         return BitNumbering.LSB
 
 
-def _reverse_int_bits(x: int, nbits: int) -> int:
+def reverse_int_bits(x: int, nbits: int) -> int:
     if nbits is None:
         nbits = x.bit_length()
     assert nbits <= 32
@@ -193,7 +193,7 @@ def _reverse_int_bits(x: int, nbits: int) -> int:
 
 def initialize_bitstring(integer: int, nbits: int = None, numbering_in: BitNumbering = BitNumbering.MSB,
                          numbering_out: BitNumbering = BitNumbering.MSB):
-    integer = _reverse_int_bits(integer, nbits) if numbering_in != numbering_out else integer
+    integer = reverse_int_bits(integer, nbits) if numbering_in != numbering_out else integer
     if numbering_out == BitNumbering.MSB:
         return BitString.from_int(integer=integer, nbits=nbits)
     else:

--- a/tests/test_simulator_backends.py
+++ b/tests/test_simulator_backends.py
@@ -275,7 +275,7 @@ def test_wfn_multitarget(simulator):
 @pytest.mark.parametrize("simulator", tequila.simulators.simulator_api.INSTALLED_SIMULATORS.keys())
 def test_wfn_multi_control(simulator):
     # currently no compiler, so that test can not succeed
-    if simulator == 'qiskit':
+    if simulator in ["qiskit", "qiskit_gpu"]:
         return
     ac = tq.gates.X([0, 1, 2])
     ac += tq.gates.Ry(target=[0], control=[1, 2], angle=2.3 / 2)


### PR DESCRIPTION
This pull request depends on https://github.com/tequilahub/tequila/pull/368.

I added support for running the Qiskit simulator on the GPU by creating a subclass that changes the device name. I used the same structure as for the Qulacs GPU simulator.

Using this requires the `qiskit-aer-gpu` package.

I also commented out the package check for `qulacs-gpu`, because that package is not maintained, instead you have to compile Qulacs with GPU support, see https://github.com/qulacs/qulacs/issues/623#issuecomment-2006123134.
