### PR TITLE
Allow generic wavefunctions as initial_state

### DIFF
--- a/src/tequila/simulators/simulator_api.py
+++ b/src/tequila/simulators/simulator_api.py
@@ -9,6 +9,7 @@ from tequila.objective import Objective, Variable, assign_variable, format_varia
 from tequila.utils.exceptions import TequilaException, TequilaWarning
 from tequila.simulators.simulator_base import BackendCircuit, BackendExpectationValue
 from tequila.circuit.noise import NoiseModel
+from tequila.wavefunction.qubit_wavefunction import QubitWaveFunction
 
 SUPPORTED_BACKENDS = ["qulacs", "qulacs_gpu", "qibo", "qiskit", "qiskit_gpu", "cirq", "pyquil", "symbolic", "qlm"]
 SUPPORTED_NOISE_BACKENDS = ["qiskit", "qiskit_gpu", "cirq", "pyquil"]  # qulacs removed in v.1.9
@@ -22,7 +23,6 @@ if typing.TYPE_CHECKING:
     from tequila.objective import Objective, Variable
     from tequila.circuit.gates import QCircuit
     import numbers.Real as RealNumber
-    from tequila.wavefunction.qubit_wavefunction import QubitWaveFunction
 
 """
 Check which simulators are installed
@@ -369,8 +369,9 @@ def simulate(objective: typing.Union['Objective', 'QCircuit', 'QTensor'],
              backend: str = None,
              noise: NoiseModel = None,
              device: str = None,
+             initial_state: Union[int, QubitWaveFunction] = 0,
              *args,
-             **kwargs) -> Union[RealNumber, 'QubitWaveFunction']:
+             **kwargs) -> Union[RealNumber, QubitWaveFunction]:
     """Simulate a tequila objective or circuit
 
     Parameters
@@ -388,6 +389,8 @@ def simulate(objective: typing.Union['Objective', 'QCircuit', 'QTensor'],
         specify a noise model to apply to simulation/sampling
     device:
         a device upon which (or in emulation of which) to sample
+    initial_state: int or QubitWaveFunction:
+        the initial state of the circuit
     *args :
 
     **kwargs :
@@ -409,7 +412,7 @@ def simulate(objective: typing.Union['Objective', 'QCircuit', 'QTensor'],
     compiled_objective = compile(objective=objective, samples=samples, variables=variables, backend=backend,
                                  noise=noise, device=device, *args, **kwargs)
 
-    return compiled_objective(variables=variables, samples=samples, *args, **kwargs)
+    return compiled_objective(variables=variables, samples=samples, initial_state=initial_state, *args, **kwargs)
 
 
 def draw(objective, variables=None, backend: str = None, name=None, *args, **kwargs):

--- a/src/tequila/simulators/simulator_base.py
+++ b/src/tequila/simulators/simulator_base.py
@@ -7,6 +7,7 @@ from tequila.circuit.compiler import change_basis
 from tequila import BitString
 from tequila.objective.objective import Variable, format_variable_dictionary
 from tequila.circuit import compiler
+from typing import Union
 
 import numbers, typing, numpy, copy, warnings
 
@@ -106,6 +107,11 @@ class BackendCircuit():
         "phase_to_z": True,
         "cc_max": True
     }
+
+    # Can be overwritten by backends that allow basis state initialization when sampling
+    supports_sampling_initialization: bool = False
+    # Can be overwritten by backends that allow initializing arbitrary states
+    supports_generic_initialization: bool = False
 
     @property
     def n_qubits(self) -> numbers.Integral:
@@ -328,7 +334,7 @@ class BackendCircuit():
         """
         self.circuit = self.create_circuit(abstract_circuit=self.abstract_circuit, variables=variables)
 
-    def simulate(self, variables, initial_state=0, *args, **kwargs) -> QubitWaveFunction:
+    def simulate(self, variables, initial_state: Union[int, QubitWaveFunction] = 0, *args, **kwargs) -> QubitWaveFunction:
         """
         simulate the circuit via the backend.
 
@@ -348,13 +354,12 @@ class BackendCircuit():
             the wavefunction of the system produced by the action of the circuit on the initial state.
 
         """
+        if isinstance(initial_state, QubitWaveFunction) and not self.supports_generic_initialization:
+            raise TequilaException("Backend does not support arbitrary initial states")
+
         self.update_variables(variables)
         if isinstance(initial_state, BitString):
             initial_state = initial_state.integer
-        if isinstance(initial_state, QubitWaveFunction):
-            if initial_state.length() != 1:
-                raise TequilaException("only product states as initial states accepted")
-            initial_state = list(initial_state.keys())[0].integer
 
         all_qubits = list(range(self.abstract_circuit.n_qubits))
         active_qubits = self.qubit_map.keys()
@@ -362,11 +367,21 @@ class BackendCircuit():
         # Keymap is only necessary if not all qubits are active
         keymap_required = sorted(active_qubits) != all_qubits
 
+        # Combining keymap and general initial states is awkward, because it's not clear what should happen with
+        # different states on non-active qubits. For now, this is simply not allowed.
+        # A better solution might be to check if all components of the initial state differ only on the active qubits.
+        if keymap_required and isinstance(initial_state, QubitWaveFunction):
+            raise TequilaException("Can only set non-basis initial state if all qubits are used")
+
         if keymap_required:
             # maps from reduced register to full register
             keymap = KeyMapSubregisterToRegister(subregister=active_qubits, register=all_qubits)
 
-        mapped_initial_state = keymap.inverted(initial_state).integer if keymap_required else int(initial_state)
+        if not isinstance(initial_state, QubitWaveFunction):
+            mapped_initial_state = keymap.inverted(initial_state).integer if keymap_required else int(initial_state)
+        else:
+            mapped_initial_state = initial_state
+
         result = self.do_simulate(variables=variables, initial_state=mapped_initial_state, *args,
                                   **kwargs)
 
@@ -375,7 +390,7 @@ class BackendCircuit():
 
         return result
 
-    def sample(self, variables, samples, read_out_qubits=None, circuit=None, *args, **kwargs):
+    def sample(self, variables, samples, read_out_qubits=None, circuit=None, initial_state=0, *args, **kwargs):
         """
         Sample the circuit. If circuit natively equips paulistrings, sample therefrom.
         Parameters
@@ -395,6 +410,12 @@ class BackendCircuit():
             The result of sampling, a recreated QubitWaveFunction in the sampled basis.
 
         """
+        if initial_state != 0 and not self.supports_sampling_initialization:
+            raise TequilaException("Backend does not support initial states for sampling")
+
+        if isinstance(initial_state, QubitWaveFunction) and not self.supports_generic_initialization:
+            raise TequilaException("Backend does not support arbitrary initial states")
+
         self.update_variables(variables)
         if read_out_qubits is None:
             read_out_qubits = self.abstract_qubits
@@ -406,7 +427,9 @@ class BackendCircuit():
             circuit = self.add_measurement(circuit=self.circuit, target_qubits=read_out_qubits)
         else:
             circuit = self.add_measurement(circuit=circuit, target_qubits=read_out_qubits)
-        return self.do_sample(samples=samples, circuit=circuit, read_out_qubits=read_out_qubits, *args, **kwargs)
+
+        return self.do_sample(samples=samples, circuit=circuit, read_out_qubits=read_out_qubits,
+                              initial_state=initial_state, *args, **kwargs)
 
     def sample_all_z_hamiltonian(self, samples: int, hamiltonian, variables, *args, **kwargs):
         """
@@ -511,7 +534,7 @@ class BackendCircuit():
         E = E / samples * paulistring.coeff
         return E
 
-    def do_sample(self, samples, circuit, noise, abstract_qubits=None, *args, **kwargs) -> QubitWaveFunction:
+    def do_sample(self, samples, circuit, noise, abstract_qubits=None, initial_state=0, *args, **kwargs) -> QubitWaveFunction:
         """
         helper function for sampling. MUST be overwritten by inheritors.
 
@@ -777,7 +800,7 @@ class BackendExpectationValue:
                 raise TequilaException(
                     "BackendExpectationValue received not all variables. Circuit depends on variables {}, you gave {}".format(
                         self._variables, variables))
-        
+
         if samples is None:
             data = self.simulate(variables=variables, *args, **kwargs)
         else:
@@ -856,7 +879,7 @@ class BackendExpectationValue:
             samples = max(1, int(self.abstract_expectationvalue.samples * total_samples))
             suggested = samples
             # samples are not necessarily set (either the user has to set it or some functions like optimize_measurements)
- 
+
         if suggested is not None and suggested != samples:
             warnings.warn("simulating with samples={}, but expectationvalue carries suggested samples={}\nTry calling with samples='auto-total#ofsamples'".format(samples, suggested), TequilaWarning)
 

--- a/src/tequila/simulators/simulator_qulacs_gpu.py
+++ b/src/tequila/simulators/simulator_qulacs_gpu.py
@@ -1,16 +1,18 @@
 import qulacs
+from qulacs_core import QuantumStateGpu
+
 from tequila import TequilaException
 from tequila.simulators.simulator_qulacs import BackendCircuitQulacs, BackendExpectationValueQulacs
+
 
 class TequilaQulacsGpuException(TequilaException):
     def __str__(self):
         return "Error in qulacs gpu backend:" + self.message
 
+
 class BackendCircuitQulacsGpu(BackendCircuitQulacs):
-    def initialize_state(self, n_qubits:int=None) -> qulacs.QuantumState:
-        if n_qubits is None:
-            n_qubits = self.n_qubits
-        return qulacs.QuantumStateGpu(n_qubits)
+    quantum_state_class = QuantumStateGpu
+
 
 class BackendExpectationValueQulacsGpu(BackendExpectationValueQulacs):
     BackendCircuitType = BackendCircuitQulacsGpu

--- a/tests/test_simulator_backends.py
+++ b/tests/test_simulator_backends.py
@@ -4,12 +4,13 @@ All Backends need to be installed for full testing
 
 import importlib
 import numpy
+import numpy as np
 import pytest
 import random
 import numbers
 import tequila as tq
 import tequila.simulators.simulator_api
-from tequila import BitString
+from tequila import BitString, QubitWaveFunction
 
 """
 Warn if Simulators are not installed
@@ -354,6 +355,25 @@ def test_initial_state_from_integer(simulator, initial_state):
     wfn = tq.simulate(U, initial_state=initial_state, backend=simulator)
     assert BitString.from_int(initial_state, 6) in wfn
     assert numpy.isclose(wfn[BitString.from_int(initial_state, 6)], 1.0)
+
+
+@pytest.mark.parametrize("simulator", tequila.simulators.simulator_api.INSTALLED_SIMULATORS.keys())
+def test_initial_state_from_wavefunction(simulator):
+    if not tequila.simulators.simulator_api.INSTALLED_SIMULATORS[simulator][0].supports_generic_initialization:
+        return
+
+    U = tq.gates.H(target=0)
+
+    state = QubitWaveFunction.from_array(np.array([1.0, 1.0])).normalize()
+    result = tq.simulate(U, initial_state=state, backend=simulator)
+    assert result.isclose(QubitWaveFunction.from_basis_state(n_qubits=1, basis_state=0))
+    result = tq.simulate(U, initial_state=state, backend=simulator, samples=100)
+    assert result.isclose(QubitWaveFunction.from_array(np.array([100.0, 0.0])))
+
+    state = QubitWaveFunction.from_array(np.array([1.0, -1.0])).normalize()
+    result = tq.simulate(U, initial_state=state, backend=simulator, samples=100)
+    assert result.isclose(QubitWaveFunction.from_array(np.array([0.0, 100.0])))
+
 
 
 @pytest.mark.parametrize("backend", tequila.simulators.simulator_api.INSTALLED_SIMULATORS.keys())


### PR DESCRIPTION
This pull request depends on https://github.com/tequilahub/tequila/pull/370.

For the Qulacs and Qiskit backend, it makes it possible to initialize circuits with arbitrary wavefunctions instead of only basis states.
This also adds the parameter for sampling and to `tq.simulate`.

I have added boolean flags to the backend circuit objects that indicate which backends support this and throw an error message when necessary. This doesn't seem ideal, but I didn't want to change the other backends that I can't test.

Also, combining initial states with a keymap is awkward, I think it only makes sense if we assume that all states on the inactive qubits are the same. For now I disabled it and throw an error message.
I noticed that there's no keymap for sampling, can we get rid of it for simulating too?

Example usage:

```python
import numpy as np
import tequila as tq
from tequila import QubitWaveFunction

U = tq.gates.H(target=0)
state = QubitWaveFunction.from_array(np.array([1.0, 1.0])).normalize()

result = tq.simulate(U, initial_state=state, backend="qulacs")
assert result.isclose(QubitWaveFunction.from_basis_state(n_qubits=1, basis_state=0))

result = tq.simulate(U, initial_state=state, backend="qulacs", samples=100)
assert result.isclose(QubitWaveFunction.from_array(np.array([100.0, 0.0])))
```