### PR TITLE
Add initial state support for expectation values

### DIFF
--- a/src/tequila/objective/objective.py
+++ b/src/tequila/objective/objective.py
@@ -1,4 +1,5 @@
 import typing, copy, numbers
+from typing import Union
 from tequila.grouping.compile_groups import compile_commuting_parts
 from tequila import TequilaException
 from tequila.utils import JoinedTransformation
@@ -545,7 +546,7 @@ class Objective:
                "variables          = {}\n" \
                "types              = {}".format(unique, measurements, variables, types)
 
-    def __call__(self, variables=None, *args, **kwargs):
+    def __call__(self, variables=None, initial_state = 0, *args, **kwargs):
         """
         Return the output of the calculation the objective represents.
 
@@ -553,6 +554,8 @@ class Objective:
         ----------
         variables: dict:
             dictionary instantiating all variables that may appear within the objective.
+        initial_state: int or QubitWaveFunction:
+            the initial state of the circuit
         args
         kwargs
 
@@ -579,7 +582,7 @@ class Objective:
         ev_array = []
         for E in self.args:
             if E not in evaluated:  #
-                expval_result = E(variables=variables, *args, **kwargs)
+                expval_result = E(variables=variables, initial_state=initial_state, *args, **kwargs)
                 evaluated[E] = expval_result
             else:
                 expval_result = evaluated[E]

--- a/tests/test_simulator_backends.py
+++ b/tests/test_simulator_backends.py
@@ -371,8 +371,19 @@ def test_initial_state_from_wavefunction(simulator):
     assert result.isclose(QubitWaveFunction.from_array(np.array([100.0, 0.0])))
 
     state = QubitWaveFunction.from_array(np.array([1.0, -1.0])).normalize()
+    result = tq.simulate(U, initial_state=state, backend=simulator)
+    assert result.isclose(QubitWaveFunction.from_basis_state(n_qubits=1, basis_state=1))
     result = tq.simulate(U, initial_state=state, backend=simulator, samples=100)
     assert result.isclose(QubitWaveFunction.from_array(np.array([0.0, 100.0])))
+
+    U = tq.gates.X(target=0)
+    H = tq.paulis.Z(qubit=0)
+    E = tq.ExpectationValue(U, H)
+    state = QubitWaveFunction.from_array(np.array([0.0, 1.0])).normalize()
+    result = tq.simulate(E, initial_state=state, backend=simulator)
+    assert numpy.isclose(result, 1.0)
+    result = tq.simulate(E, initial_state=state, backend=simulator, samples=100)
+    assert numpy.isclose(result, 1.0)
 
 
 


### PR DESCRIPTION
I didn't realize that my previous pull request worked only for directly simulating circuits, not computing expectation values. This should fix that, though I'm still not sure if I caught all the code paths this time.