### PR TITLE
Improve circuit compilation performance

### DIFF
--- a/src/tequila/utils/bitstrings.py
+++ b/src/tequila/utils/bitstrings.py
@@ -69,6 +69,12 @@ class BitString:
         self.update_nbits()
         return self
 
+    def to_integer(self, numbering: BitNumbering):
+        if numbering == self.numbering:
+            return self.integer
+        else:
+            return reverse_int_bits(self.integer, self.nbits)
+
     @property
     def array(self):
         return [int(i) for i in self.binary]

--- a/src/tequila/wavefunction/qubit_wavefunction.py
+++ b/src/tequila/wavefunction/qubit_wavefunction.py
@@ -365,7 +365,7 @@ class QubitWaveFunction:
     # because the __mul__ implementation of the number tries to perform some sort of array
     # operation.
     def length(self):
-        return sum(1 for _ in self.raw_items())
+        return sum(1 for (k, v) in self.raw_items() if abs(v) > 1e-6)
 
     def __repr__(self):
         result = str()


### PR DESCRIPTION
This PR speeds up working with and compiling large circuits.

Here is a simple benchmark to test this:

<details>
<summary>Code</summary>

```python
import tequila as tq
import random
from time import time

if __name__ == "__main__":
    random.seed(0)
    start = time()

    circuit = tq.QCircuit()
    for i in range(100):
        subcircuit = tq.QCircuit()
        for j in range(100):
            qubits = random.sample(range(10), 3)
            subcircuit += tq.gates.Toffoli(qubits[0], qubits[1], qubits[2])
            subcircuit += tq.gates.Ry(0.5, random.choice(range(10)))
        circuit += subcircuit

    daggered = circuit.dagger()
    circuit += daggered

    tq.simulate(circuit, backend="qulacs", optimize_circuit=False)

    print(f"Time: {time() - start:.3f} s")
```

</details>

Having `optimize_circuit=False` is necessary, without it the Qulacs optimization will take very long.

Before this pull request, the script took about 17 seconds on my machine.

The first change is to revert https://github.com/tequilahub/tequila/pull/360, because I didn't realize how big the performance impact of the deepcopy call here is.
I don't like removing this, but it reduces the runtime to around 10 seconds, and it seems like it was fine without the copy for years before I made that pull request.
I extended the warning message to explain the specific case that made me add the copy.

The second change is optimizing the `replace_gates` function, because it is currently implemented in an inefficient way that performs a lot of unnecessary copying. This change reduces the runtime of the script to about 3 seconds.

I also fixed a problem in the `QubitWaveFunction` `length` method where it also counted zeros, and added a function for `BitString` that returns the stored integer in a specified bit ordering.