### PR TITLE
Remove Qiskit noise feature and transpile circuit

### DIFF
--- a/src/tequila/simulators/simulator_api.py
+++ b/src/tequila/simulators/simulator_api.py
@@ -12,7 +12,8 @@ from tequila.circuit.noise import NoiseModel
 from tequila.wavefunction.qubit_wavefunction import QubitWaveFunction
 
 SUPPORTED_BACKENDS = ["qulacs", "qulacs_gpu", "qibo", "qiskit", "qiskit_gpu", "cirq", "pyquil", "symbolic", "qlm"]
-SUPPORTED_NOISE_BACKENDS = ["qiskit", "qiskit_gpu", "cirq", "pyquil"]  # qulacs removed in v.1.9
+# TODO: Reenable noise for Qiskit
+SUPPORTED_NOISE_BACKENDS = ["cirq", "pyquil"]  # qulacs removed in v.1.9
 BackendTypes = namedtuple('BackendTypes', 'CircType ExpValueType')
 INSTALLED_SIMULATORS = {}
 INSTALLED_SAMPLERS = {}


### PR DESCRIPTION
- The Qiskit noise feature seems to be broken, (temporarily?) removed it from `SUPPORTED_NOISE_BACKENDS`
- I forgot to transpile in my previous pull request which caused the `test_wfn_simple_consistency` test to fail, fixed that (surprisingly, all the other tests seemed fine even without)
- Added a check for `HAS_IBMQ` before testing if a backend is an `IBMBackend` so that the code works without the package installed. (I don't think the IBMQ code is tested though, because it requires an IBMQ account).