### PR TITLE
Fix backends CI

### DIFF
--- a/.github/workflows/ci_backends.yml
+++ b/.github/workflows/ci_backends.yml
@@ -31,7 +31,7 @@ jobs:
         if [ $ver -eq 7 ]; then
             # myqlm does not work in python3.7
             pip install "cirq" "qiskit>=0.30" "qulacs" "qibo==0.1.1"
-        elif [ $ver -eq 8 ]; then
+        elif [ $ver -eq 9 ]; then
             pip install "cirq" "qiskit" "qulacs" "qibo==0.1.1" "myqlm" "cirq-google"
         fi
         pip install -e .

--- a/.github/workflows/ci_backends.yml
+++ b/.github/workflows/ci_backends.yml
@@ -28,11 +28,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        ver=$(python -c "import sys; print(sys.version_info.minor)")
         if [ $ver -eq 7 ]; then
             # myqlm does not work in python3.7
             pip install "cirq" "qiskit>=0.30" "qulacs" "qibo==0.1.1"
         elif [ $ver -eq 9 ]; then
-            pip install "cirq" "qiskit" "qulacs" "qibo==0.1.1" "myqlm" "cirq-google"
+            pip install "cirq" "qiskit" "qiskit-aer" "qulacs" "qibo" "myqlm" "cirq-google"
         fi
         pip install -e .
     - name: Lint with flake8


### PR DESCRIPTION
Makes the ci_backends test run, which didn't work before because of a problem in the version check.
Commits are originally from https://github.com/tequilahub/tequila/pull/378.

Also since CI seems to only run on 3.9 anyways, we can probably remove the if conditions?