### PR TITLE
Qiskit CI

### DIFF
--- a/.github/workflows/ci_backends.yml
+++ b/.github/workflows/ci_backends.yml
@@ -34,7 +34,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install "qiskit" "qulacs"
+        # TODO: Update to Qiskit 2.0
+        pip install "qulacs" "qiskit==1.*" "qiskit-aer"
         # pip install cirq # installs too much stuff currently
         pip install -e . 
     - name: Lint with flake8


### PR DESCRIPTION
I think the Qiskit backend isn't being tested in CI because `qiskit-aer` isn't installed, this should fix that.