### PR TITLE
Add FCI wavefunction to pyscf backend

### DIFF
--- a/src/tequila/quantumchemistry/qc_base.py
+++ b/src/tequila/quantumchemistry/qc_base.py
@@ -1695,6 +1695,9 @@ class QuantumChemistryBase:
                 from tequila.quantumchemistry import QuantumChemistryPySCF
                 molx = QuantumChemistryPySCF.from_tequila(self)
                 return molx.compute_energy(method=method)
+    
+    def compute_fci(self, *args, **kwargs):
+        raise NotImplementedError("compute_fci only implemented for the 'pyscf' backend")
 
     def compute_fock_matrix(self):
         c, h, g = self.get_integrals()


### PR DESCRIPTION
Closes #406 

- Modified `compute_fci` function to return the energy and FCI wavefuncion implemented in the pyscf backend.
- Added tests comparing results with `numpy.linalg.eigh` for small molecules.


