### PR TITLE
Implement optimized compiling for general QubitExcitations beyond single and double

### DIFF
--- a/tests/test_recompilation_routines.py
+++ b/tests/test_recompilation_routines.py
@@ -159,8 +159,7 @@ def test_compile_ch(target, control, power):
         assert (equivalent_circuit == equivalent_ch)
 
 
-@pytest.mark.parametrize("simulator", simulators)
-def test_compile_qubit_excitations(simulator):
+def test_compile_qubit_excitations():
 
     # Test 3-qubit excitation
 
@@ -181,8 +180,8 @@ def test_compile_qubit_excitations(simulator):
         compile_options="pauli",
     )
     U2 = compile_circuit(circuit)
-    wfn1 = simulate(U1, backend=simulator)
-    wfn2 = simulate(U2, backend=simulator)
+    wfn1 = simulate(U1)
+    wfn2 = simulate(U2)
 
     assert U1.depth < U2.depth
     assert isclose(numpy.abs(wfn1.inner(wfn2)) ** 2, 1.0)
@@ -197,8 +196,8 @@ def test_compile_qubit_excitations(simulator):
     U1 = compile_circuit(gates.QubitExcitation(angle=angle,target=q)) # optimized
     U2 = compile_circuit(gates.QubitExcitation(angle=angle,target=q, compile_options="pauli"))
 
-    wfn1 = simulate(U1, backend=simulator, initial_state=state)
-    wfn2 = simulate(U2, backend=simulator, initial_state=state)
+    wfn1 = simulate(U1, initial_state=state)
+    wfn2 = simulate(U2, initial_state=state)
 
     assert U1.depth < U2.depth
     assert isclose(numpy.abs(wfn1.inner(wfn2)) ** 2, 1.0)

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -72,7 +72,7 @@ def test_gradient_free_methods(simulator, method):
 
     initial_values = {"a": 0.1, "b": 0.01}
     if method == "SLSQP":  # method is not good
-        return True
+        return
 
     result = tq.optimizer_scipy.minimize(objective=-E, method=method, tol=1.e-4, backend=simulator,
                                          initial_values=initial_values, silent=True)


### PR DESCRIPTION
Closes #400 

- Modified `compile` method in `QubitExcitationImpl` to support general n-qubit excitations.
- Added tests comparing both fidelity and depth against non-optimized decompositions.

 
