### PR TITLE
Fix Identity Hamiltonian

### DIFF
--- a/src/tequila/simulators/simulator_qulacs.py
+++ b/src/tequila/simulators/simulator_qulacs.py
@@ -499,7 +499,7 @@ class BackendExpectationValueQulacs(BackendExpectationValue):
 
         # map the reduced operators to the potentially smaller qubit system
         qubit_map = {}
-        for i, q in enumerate(self.U.abstract_circuit.qubits):
+        for i, q in enumerate(self.U.abstract_qubits):
             qubit_map[q] = i
 
         result = []


### PR DESCRIPTION
This changes how the qubit map for hamiltonians is built in Qulacs expectation vaues which should fix a problem with identity gates.

@JdelArco98 Could you check if this solves your issue?