### PR TITLE
allows for initialization of parametersqc class with bohr units with conversion to angstrom and vice versa

### DIFF
--- a/src/tequila/quantumchemistry/chemistry_tools.py
+++ b/src/tequila/quantumchemistry/chemistry_tools.py
@@ -457,7 +457,7 @@ class ParametersQC:
             A list with the correct format for openfermion E.g return [ ('h',(0.0,0.0,0.0)), (..)], coordinates are in "desired_units",
             note that openfermion requires coordinates in angstrom
         """
-        c_bohrtoang = physical_constants["Bohr radius"][0]*10**10
+        c_bohrtoang = physical_constants["Bohr radius"][0] * 10**10
         result = []
         # Remove blank lines
         lines = [l for l in geometry.split("\n") if l]

--- a/src/tequila/quantumchemistry/chemistry_tools.py
+++ b/src/tequila/quantumchemistry/chemistry_tools.py
@@ -283,8 +283,10 @@ class ParametersQC:
     """Specialization of ParametersHamiltonian"""
 
     basis_set: str = None  # Quantum chemistry basis set
-    geometry: str = None  # geometry of the underlying molecule (units: Angstrom!),
+    geometry: str = None  # geometry of the underlying molecule,
     # this can be a filename leading to an .xyz file or the geometry given as a string
+    units:str = None # units of the geometry, if nothing is passed it will be set to Angstrom!
+    silent:bool = False
     description: str = ""
     multiplicity: int = 1
     charge: int = 0
@@ -360,6 +362,21 @@ class ParametersQC:
             raise TequilaException(
                 "no geometry or name given to molecule\nprovide geometry=filename.xyz or geometry=`h 0.0 0.0 0.0\\n...`\nor name=whatever with file whatever.xyz being present"
             )
+        #determine units, default Angstrom
+        if self.units is None:
+            if not self.silent:
+                print("Warning: No units passed with geometry, assuming units are angstrom.")
+            self.units = "angstrom"
+        else:
+            self.units = self.units.lower()
+            if self.units in ["angstrom", "ang", "a", "å"]:
+                self.units = "angstrom"
+            elif self.units in ["bohr", "atomic units", "au", "a.u."]:
+                self.units = "bohr"
+            else:
+                if not self.silent:
+                    print("Warning: Units passed with geometry not recognized (available units are angstrom or bohr), assuming units are angstrom.")
+                self.units = "angstrom"
         # auto naming
         if self.name is None:
             if ".xyz" in self.geometry:
@@ -391,7 +408,7 @@ class ParametersQC:
         """:return: Give back all parameters for the MolecularData format from openfermion as dictionary"""
         return {
             "basis": self.basis_set,
-            "geometry": self.get_geometry(),
+            "geometry": self.get_geometry(desired_units="angstrom"),
             "description": self.description,
             "charge": self.charge,
             "multiplicity": self.multiplicity,
@@ -420,20 +437,24 @@ class ParametersQC:
         return fstring
 
     @staticmethod
-    def convert_to_list(geometry):
+    def convert_to_list(geometry, initial_units, desired_units):
         """Convert a molecular structure given as a string into a list suitable for openfermion
 
         Parameters
         ----------
         geometry :
-            a string specifying a mol. structure. E.g. geometry="h 0.0 0.0 0.0\n h 0.0 0.0 1.0"
-
+            a string specifying a mol. structure. E.g. geometry="h 0.0 0.0 0.0\n h 0.0 0.0 1.0",
+        initial_units :
+            the units of the input geometry
+        desired_units :
+            the units of the output coordinates
         Returns
         -------
         type
-            A list with the correct format for openfermion E.g return [ ['h',[0.0,0.0,0.0], [..]]
-
+            A list with the correct format for openfermion E.g return [ ('h',(0.0,0.0,0.0)), (..)], coordinates are in "desired_units",
+            note that openfermion requires coordinates in angstrom
         """
+        c_bohrtoang = 0.52917720859
         result = []
         # Remove blank lines
         lines = [l for l in geometry.split("\n") if l]
@@ -446,54 +467,55 @@ class ParametersQC:
                 words += [0.0] * (4 - len(words))
 
             try:
-                tmp = (ParametersQC.format_element_name(words[0]), (float(words[1]), float(words[2]), float(words[3])))
+                if initial_units==desired_units:
+                    tmp = (ParametersQC.format_element_name(words[0]), (float(words[1]), float(words[2]), float(words[3])))
+                elif initial_units=="angstrom":
+                    tmp = (ParametersQC.format_element_name(words[0]), (float(words[1])/c_bohrtoang, float(words[2])/c_bohrtoang, float(words[3])/c_bohrtoang))
+                elif initial_units=="bohr":
+                    tmp = (ParametersQC.format_element_name(words[0]), (float(words[1])*c_bohrtoang, float(words[2])*c_bohrtoang, float(words[3])*c_bohrtoang))
                 result.append(tmp)
             except ValueError:
                 print("get_geometry list unknown line:\n ", line, "\n proceed with caution!")
         return result
 
-    def get_geometry_string(self) -> str:
+    def get_geometry_string(self, desired_units="angstrom") -> str:
         """returns the geometry as a string
-        :return: geometry string
-
-        Parameters
-        ----------
-
-        Returns
-        -------
+        :return: geometry string, if desired_units is not equal to self.units, the coordinates will be transformed to "desired_units"
 
         """
-        if self.geometry.split(".")[-1] == "xyz":
-            geomstring, comment = self.read_xyz_from_file(self.geometry)
-            if comment is not None:
-                self.description = comment
-            return geomstring
-        else:
-            return self.geometry
+        geom = self.get_geometry(desired_units=desired_units)
+        f=""
+        for at in geom:
+            f += f"{at[0]} {at[1][0]} {at[1][1]} {at[1][2]}\n"
+        return f
 
-    def get_geometry(self):
+
+    def get_geometry(self, desired_units="angstrom"):
         """Returns the geometry
         If a xyz filename was given the file is read out
         otherwise it is assumed that the geometry was given as string
         which is then reformatted as a list usable as input for openfermion
         :return: geometry as list
         e.g. [(h,(0.0,0.0,0.35)),(h,(0.0,0.0,-0.35))]
-        Units: Angstrom!
-
-        Parameters
-        ----------
-
-        Returns
-        -------
-
+        Coordinates are transformed into the "desired_units", note that openfermion requires coordinates in Angstrom!
         """
+        desired_units = desired_units.lower()
+        if desired_units in ["angstrom", "ang", "a", "å"]:
+            desired_units = "angstrom"
+        elif desired_units in ["bohr", "atomic units", "au", "a.u."]:
+            desired_units = "bohr"
+        else:
+            if not self.silent:
+                print("Warning: Desired units not recognized (available units are angstrom or bohr), defaulting to angstrom.")
+            desired_units = "angstrom"
+
         if self.geometry.split(".")[-1] == "xyz":
             geomstring, comment = self.read_xyz_from_file(self.geometry)
             if self.description == "":
                 self.description = comment
-            return self.convert_to_list(geomstring)
+            return self.convert_to_list(geomstring, initial_units=self.units, desired_units=desired_units)
         elif self.geometry is not None:
-            return self.convert_to_list(self.geometry)
+            return self.convert_to_list(self.geometry, initial_units=self.units, desired_units=desired_units)
         else:
             raise Exception("Parameters.qc.geometry is None")
 
@@ -501,15 +523,11 @@ class ParametersQC:
     def read_xyz_from_file(filename):
         """Read XYZ filetype for molecular structures
         https://en.wikipedia.org/wiki/XYZ_file_format
-        Units: Angstrom!
+        Units of the geometry in the file have to be equal to self.units, default for self.units is angstrom.
 
         Parameters
         ----------
-        filename :
-            return:
-
-        Returns
-        -------
+        filename of the .xyz file
 
         """
         with open(filename, "r") as file:
@@ -521,11 +539,13 @@ class ParametersQC:
                 coord += content[2 + i]
             return coord, comment
 
-    def get_xyz(self) -> str:
-        geom = self.parameters.get_geometry()
+    def get_xyz(self, desired_units="angstrom") -> str:
+        """Returns string for a .xyz file with the coordinates in the "desired_units"
+        """
+        geom = self.get_geometry(desired_units=desired_units)
         f = ""
         f += f"{len(geom)}\n"
-        f += f"{self.parameters.name}\n"
+        f += f"{self.name}\n"
         for at in geom:
             f += f"{at[0]} {at[1][0]} {at[1][1]} {at[1][2]}\n"
         return f
@@ -534,7 +554,7 @@ class ParametersQC:
 @dataclass
 class ClosedShellAmplitudes:
     """
-    Helper Class for clasical amplitudes
+    Helper Class for classical amplitudes
     used internally
     """
 

--- a/src/tequila/quantumchemistry/chemistry_tools.py
+++ b/src/tequila/quantumchemistry/chemistry_tools.py
@@ -285,8 +285,8 @@ class ParametersQC:
     basis_set: str = None  # Quantum chemistry basis set
     geometry: str = None  # geometry of the underlying molecule,
     # this can be a filename leading to an .xyz file or the geometry given as a string
-    units:str = None # units of the geometry, if nothing is passed it will be set to Angstrom!
-    silent:bool = False
+    units: str = None  # units of the geometry, if nothing is passed it will be set to Angstrom!
+    silent: bool = False
     description: str = ""
     multiplicity: int = 1
     charge: int = 0
@@ -362,7 +362,7 @@ class ParametersQC:
             raise TequilaException(
                 "no geometry or name given to molecule\nprovide geometry=filename.xyz or geometry=`h 0.0 0.0 0.0\\n...`\nor name=whatever with file whatever.xyz being present"
             )
-        #determine units, default Angstrom
+        # determine units, default Angstrom
         if self.units is None:
             if not self.silent:
                 print("Warning: No units passed with geometry, assuming units are angstrom.")
@@ -375,7 +375,9 @@ class ParametersQC:
                 self.units = "bohr"
             else:
                 if not self.silent:
-                    print("Warning: Units passed with geometry not recognized (available units are angstrom or bohr), assuming units are angstrom.")
+                    print(
+                        "Warning: Units passed with geometry not recognized (available units are angstrom or bohr), assuming units are angstrom."
+                    )
                 self.units = "angstrom"
         # auto naming
         if self.name is None:
@@ -467,12 +469,21 @@ class ParametersQC:
                 words += [0.0] * (4 - len(words))
 
             try:
-                if initial_units==desired_units:
-                    tmp = (ParametersQC.format_element_name(words[0]), (float(words[1]), float(words[2]), float(words[3])))
-                elif initial_units=="angstrom":
-                    tmp = (ParametersQC.format_element_name(words[0]), (float(words[1])/c_bohrtoang, float(words[2])/c_bohrtoang, float(words[3])/c_bohrtoang))
-                elif initial_units=="bohr":
-                    tmp = (ParametersQC.format_element_name(words[0]), (float(words[1])*c_bohrtoang, float(words[2])*c_bohrtoang, float(words[3])*c_bohrtoang))
+                if initial_units == desired_units:
+                    tmp = (
+                        ParametersQC.format_element_name(words[0]),
+                        (float(words[1]), float(words[2]), float(words[3])),
+                    )
+                elif initial_units == "angstrom":
+                    tmp = (
+                        ParametersQC.format_element_name(words[0]),
+                        (float(words[1]) / c_bohrtoang, float(words[2]) / c_bohrtoang, float(words[3]) / c_bohrtoang),
+                    )
+                elif initial_units == "bohr":
+                    tmp = (
+                        ParametersQC.format_element_name(words[0]),
+                        (float(words[1]) * c_bohrtoang, float(words[2]) * c_bohrtoang, float(words[3]) * c_bohrtoang),
+                    )
                 result.append(tmp)
             except ValueError:
                 print("get_geometry list unknown line:\n ", line, "\n proceed with caution!")
@@ -484,11 +495,10 @@ class ParametersQC:
 
         """
         geom = self.get_geometry(desired_units=desired_units)
-        f=""
+        f = ""
         for at in geom:
             f += f"{at[0]} {at[1][0]} {at[1][1]} {at[1][2]}\n"
         return f
-
 
     def get_geometry(self, desired_units="angstrom"):
         """Returns the geometry
@@ -506,7 +516,9 @@ class ParametersQC:
             desired_units = "bohr"
         else:
             if not self.silent:
-                print("Warning: Desired units not recognized (available units are angstrom or bohr), defaulting to angstrom.")
+                print(
+                    "Warning: Desired units not recognized (available units are angstrom or bohr), defaulting to angstrom."
+                )
             desired_units = "angstrom"
 
         if self.geometry.split(".")[-1] == "xyz":
@@ -540,8 +552,7 @@ class ParametersQC:
             return coord, comment
 
     def get_xyz(self, desired_units="angstrom") -> str:
-        """Returns string for a .xyz file with the coordinates in the "desired_units"
-        """
+        """Returns string for a .xyz file with the coordinates in the "desired_units" """
         geom = self.get_geometry(desired_units=desired_units)
         f = ""
         f += f"{len(geom)}\n"

--- a/src/tequila/quantumchemistry/chemistry_tools.py
+++ b/src/tequila/quantumchemistry/chemistry_tools.py
@@ -7,7 +7,7 @@ from numbers import Real
 import numpy
 from scipy.constants import physical_constants
 
-from tequila import BitString, QCircuit, TequilaException, Variable, compile_circuit
+from tequila import BitString, QCircuit, TequilaException, TequilaWarning, Variable, compile_circuit
 from tequila.circuit import gates
 
 try:
@@ -287,7 +287,6 @@ class ParametersQC:
     geometry: str = None  # geometry of the underlying molecule,
     # this can be a filename leading to an .xyz file or the geometry given as a string
     units: str = None  # units of the geometry, if nothing is passed it will be set to Angstrom!
-    silent: bool = False
     description: str = ""
     multiplicity: int = 1
     charge: int = 0
@@ -365,8 +364,7 @@ class ParametersQC:
             )
         # determine units, default Angstrom
         if self.units is None:
-            if not self.silent:
-                print("Warning: No units passed with geometry, assuming units are angstrom.")
+            warnings.warn("Warning: No units passed with geometry, assuming units are angstrom.", TequilaWarning)
             self.units = "angstrom"
         else:
             self.units = self.units.lower()
@@ -375,10 +373,10 @@ class ParametersQC:
             elif self.units in ["bohr", "atomic units", "au", "a.u."]:
                 self.units = "bohr"
             else:
-                if not self.silent:
-                    print(
-                        "Warning: Units passed with geometry not recognized (available units are angstrom or bohr), assuming units are angstrom."
-                    )
+                warnings.warn(
+                    "Warning: Units passed with geometry not recognized (available units are angstrom or bohr), assuming units are angstrom.",
+                    TequilaWarning,
+                )
                 self.units = "angstrom"
         # auto naming
         if self.name is None:
@@ -516,10 +514,10 @@ class ParametersQC:
         elif desired_units in ["bohr", "atomic units", "au", "a.u."]:
             desired_units = "bohr"
         else:
-            if not self.silent:
-                print(
-                    "Warning: Desired units not recognized (available units are angstrom or bohr), defaulting to angstrom."
-                )
+            warnings.warn(
+                "Warning: Desired units not recognized (available units are angstrom or bohr), defaulting to angstrom.",
+                TequilaWarning,
+            )
             desired_units = "angstrom"
 
         if self.geometry.split(".")[-1] == "xyz":

--- a/src/tequila/quantumchemistry/chemistry_tools.py
+++ b/src/tequila/quantumchemistry/chemistry_tools.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from copy import deepcopy
 from numbers import Real
 import numpy
+from scipy.constants import physical_constants
 
 from tequila import BitString, QCircuit, TequilaException, Variable, compile_circuit
 from tequila.circuit import gates
@@ -456,7 +457,7 @@ class ParametersQC:
             A list with the correct format for openfermion E.g return [ ('h',(0.0,0.0,0.0)), (..)], coordinates are in "desired_units",
             note that openfermion requires coordinates in angstrom
         """
-        c_bohrtoang = 0.52917720859
+        c_bohrtoang = physical_constants["Bohr radius"][0]*10**10
         result = []
         # Remove blank lines
         lines = [l for l in geometry.split("\n") if l]

--- a/src/tequila/quantumchemistry/qc_base.py
+++ b/src/tequila/quantumchemistry/qc_base.py
@@ -224,6 +224,7 @@ class QuantumChemistryBase:
         parameters = ParametersQC(
             basis_set=molecule.basis,
             geometry=molecule.geometry,
+            units="angstrom",
             description=molecule.description,
             multiplicity=molecule.multiplicity,
             charge=molecule.charge,

--- a/tests/test_chemistry.py
+++ b/tests/test_chemistry.py
@@ -162,7 +162,9 @@ def test_dependencies():
 
 @pytest.mark.skipif(condition=not HAS_PSI4 and not HAS_PYSCF, reason="no quantum chemistry backends installed")
 def test_interface():
-    molecule = tq.chemistry.Molecule(basis_set="sto-3g", geometry="data/h2.xyz", units="angstrom", transformation="JordanWigner")
+    molecule = tq.chemistry.Molecule(
+        basis_set="sto-3g", geometry="data/h2.xyz", units="angstrom", transformation="JordanWigner"
+    )
 
 
 @pytest.mark.skipif(condition=not HAS_PSI4, reason="you don't have psi4")
@@ -176,7 +178,9 @@ def test_h2_hamiltonian_psi4():
 
 
 def do_test_h2_hamiltonian(qc_interface):
-    parameters = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g")
+    parameters = tequila.quantumchemistry.chemistry_tools.ParametersQC(
+        geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g"
+    )
     H = qc_interface(parameters=parameters).make_hamiltonian().to_matrix()
     vals = numpy.linalg.eigvalsh(H)
     assert numpy.isclose(vals[0], -1.1368354639104123, atol=1.0e-4)
@@ -193,7 +197,9 @@ def do_test_h2_hamiltonian(qc_interface):
 def test_ucc_psi4(trafo, backend):
     if backend == "symbolic":
         pytest.skip("skipping for symbolic simulator  ... way too slow")
-    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g")
+    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(
+        geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g"
+    )
     do_test_ucc(
         qc_interface=qc.QuantumChemistryPsi4,
         parameters=parameters_qc,
@@ -205,7 +211,9 @@ def test_ucc_psi4(trafo, backend):
 
 @pytest.mark.skipif(condition=not HAS_PSI4, reason="you don't have psi4")
 def test_ucc_singles_psi4():
-    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="6-31G")
+    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(
+        geometry="data/h2.xyz", units="angstrom", basis_set="6-31G"
+    )
     # default backend is fine
     # will not converge if singles are not added
     do_test_ucc(
@@ -233,7 +241,9 @@ def do_test_ucc(qc_interface, parameters, result, trafo, backend="qulacs"):
 def test_mp2_psi4():
     # the number might be wrong ... its definetely not what psi4 produces
     # however, no reason to expect projected MP2 is the same as UCC with MP2 amplitudes
-    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g")
+    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(
+        geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g"
+    )
     do_test_mp2(qc_interface=qc.QuantumChemistryPsi4, parameters=parameters_qc, result=-1.1344497203826904)
 
 
@@ -259,7 +269,9 @@ def test_amplitudes_psi4(method):
     results = {"mp2": -1.1279946983462537, "cc2": -1.1344484090805054, "ccsd": None, "cc3": None}
     # the number might be wrong ... its definitely not what psi4 produces
     # however, no reason to expect projected MP2 is the same as UCC with MP2 amplitudes
-    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g")
+    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(
+        geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g"
+    )
     do_test_amplitudes(
         method=method, qc_interface=qc.QuantumChemistryPsi4, parameters=parameters_qc, result=results[method]
     )
@@ -286,7 +298,9 @@ def do_test_amplitudes(method, qc_interface, parameters, result):
 @pytest.mark.parametrize("method", ["mp2", "mp3", "mp4", "cc2", "cc3", "ccsd", "ccsd(t)", "cisd", "cisdt"])
 def test_energies_psi4(method):
     # mp3 needs C1 symmetry
-    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="6-31g")
+    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(
+        geometry="data/h2.xyz", units="angstrom", basis_set="6-31g"
+    )
     if method in ["mp3", "mp4"]:
         psi4_interface = qc.QuantumChemistryPsi4(parameters=parameters_qc, point_group="c1")
     else:
@@ -314,7 +328,11 @@ def test_restart_psi4():
 
     wfnx.to_file("data/test_wfn.npy")
     h2 = tq.chemistry.Molecule(
-        geometry="data/h2.xyz", units="angstrom", basis_set="6-31g", name="data/andreasdorn", guess_wfn="data/test_wfn.npy"
+        geometry="data/h2.xyz",
+        units="angstrom",
+        basis_set="6-31g",
+        name="data/andreasdorn",
+        guess_wfn="data/test_wfn.npy",
     )
     # with open(h2.logs['hf'].filename, "r") as f:
     #     found = False
@@ -346,7 +364,9 @@ def test_rdms_psi4():
             [[[0.0, 0.0], [0.0, 0.0]], [[-0.21275021, 0.0], [0.0, 0.02289338]]],
         ]
     )
-    mol = qc.Molecule(geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g", backend="psi4", transformation="jordan-wigner")
+    mol = qc.Molecule(
+        geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g", backend="psi4", transformation="jordan-wigner"
+    )
     # Check matrices by psi4
     mol.compute_rdms(
         U=None, psi4_method="detci", psi4_options={"detci__ex_level": 2, "detci__opdm": True, "detci__tpdm": True}
@@ -429,7 +449,9 @@ def test_hamiltonian_reduction(backend):
     "trafo", ["jordan_wigner", "bravyi_kitaev", "reordered_jordan_wigner", "TaperedBinary", "REORDEREDTAPEREDBINARY"]
 )
 def test_fermionic_gates(assume_real, trafo):
-    mol = tq.chemistry.Molecule(geometry="H 0.0 0.0 0.7\nLi 0.0 0.0 0.0", units="angstrom", basis_set="sto-3g", transformation=trafo)
+    mol = tq.chemistry.Molecule(
+        geometry="H 0.0 0.0 0.7\nLi 0.0 0.0 0.0", units="angstrom", basis_set="sto-3g", transformation=trafo
+    )
     U1 = mol.prepare_reference()
     U2 = mol.prepare_reference()
     variable_count = {}
@@ -497,7 +519,11 @@ def test_hcb(trafo):
     assert numpy.isclose(energy1, -15.527740838656282, atol=1.0e-3)
 
     mol2 = tq.Molecule(
-        geometry=geomstring, units="angstrom", active_orbitals=[1, 2, 3, 4, 5, 6], basis_set="sto-3g", transformation=trafo
+        geometry=geomstring,
+        units="angstrom",
+        active_orbitals=[1, 2, 3, 4, 5, 6],
+        basis_set="sto-3g",
+        transformation=trafo,
     )
     H = mol2.make_hamiltonian()
     U = mol2.make_upccgsd_ansatz(name="UpCCGD", hcb_optimization=False)
@@ -575,7 +601,9 @@ def test_orbital_optimization():
 
 @pytest.mark.skipif(condition=not HAS_PYSCF, reason="pyscf not found")
 def test_orbital_transformation():
-    mol0 = tq.Molecule(geometry="Li 0.0 0.0 0.0\nH 0.0 0.0 0.75", units="angstrom", basis_set="STO-3G", frozen_core=False)
+    mol0 = tq.Molecule(
+        geometry="Li 0.0 0.0 0.0\nH 0.0 0.0 0.75", units="angstrom", basis_set="STO-3G", frozen_core=False
+    )
     mol0.print_basis_info()
     mol1 = mol0.orthonormalize_basis_orbitals()
 
@@ -615,7 +643,9 @@ def test_orbital_transformation():
 def test_native_active_space(system, core):
     mol = tq.Molecule(geometry=system, units="angstrom", basis_set="sto-3g", frozen_core=False, frozen_orbitals=core)
     eival, eivect = numpy.linalg.eigh(mol.make_hamiltonian().to_matrix())
-    mol = tq.Molecule(geometry=system, units="angstrom", basis_set="sto-3g", frozen_core=False).use_native_orbitals(core=core)
+    mol = tq.Molecule(geometry=system, units="angstrom", basis_set="sto-3g", frozen_core=False).use_native_orbitals(
+        core=core
+    )
     eival1, eivect1 = numpy.linalg.eigh(mol.make_hamiltonian().to_matrix())
     assert numpy.allclose(eival, eival1)
 
@@ -671,7 +701,13 @@ def test_spa_ansatz_be():
     print(not HAS_PSI4 and not HAS_PYSCF)
     edges = [(0,), (1, 2, 3, 4)]
     # doing without frozen-core to test explicitly if single-orbital pairs work
-    mol = tq.Molecule(geometry="be 0.0 0.0 0.0", units="angstrom", basis_set="sto-3g", transformation="BravyiKitaev", frozen_core=False)
+    mol = tq.Molecule(
+        geometry="be 0.0 0.0 0.0",
+        units="angstrom",
+        basis_set="sto-3g",
+        transformation="BravyiKitaev",
+        frozen_core=False,
+    )
     H = mol.make_hamiltonian()
     U = mol.make_ansatz(name="SPA", edges=edges)
     E = tq.ExpectationValue(H=H, U=U)
@@ -702,7 +738,9 @@ def test_spa_ansatz_be():
 @pytest.mark.parametrize("transformation", tq.quantumchemistry.encodings.known_encodings())
 @pytest.mark.skipif(condition=not HAS_PSI4 and not HAS_PYSCF, reason="psi4/pyscf not found")
 def test_spa_consistency(geometry, name, optimize, transformation):
-    mol = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", transformation=transformation).use_native_orbitals()
+    mol = tq.Molecule(
+        geometry=geometry, units="angstrom", basis_set="sto-3g", transformation=transformation
+    ).use_native_orbitals()
 
     # test compares HCB and non-HCB SPA implementations
     # conversion needs to be implemented for comparisson
@@ -756,7 +794,9 @@ def test_variable_consistency():
     E = tq.ExpectationValue(H=H, U=U)
     E2 = tq.simulate(E, variables=variables)
 
-    mol = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", transformation="JordanWigner").use_native_orbitals()
+    mol = tq.Molecule(
+        geometry=geometry, units="angstrom", basis_set="sto-3g", transformation="JordanWigner"
+    ).use_native_orbitals()
     U = mol.make_ansatz("SPA", edges=[(0, 1), (2, 3)])
     H = mol.make_hamiltonian(condensed=False)
     E = tq.ExpectationValue(H=H, U=U)

--- a/tests/test_chemistry.py
+++ b/tests/test_chemistry.py
@@ -36,7 +36,7 @@ def teardown_function(function):
 
 @pytest.mark.skipif(condition=not HAS_PSI4 and not HAS_PYSCF, reason="you don't have psi4 or pyscf")
 def test_UR_and_UC():
-    mol = tq.Molecule(geometry="h 0.0 0.0 0.0\nH 0.0 0.0 1.5", basis_set="sto-3g")
+    mol = tq.Molecule(geometry="h 0.0 0.0 0.0\nH 0.0 0.0 1.5", units="angstrom", basis_set="sto-3g")
     mol = mol.use_native_orbitals()
     H = mol.make_hamiltonian()
     U = mol.prepare_reference()
@@ -68,6 +68,7 @@ def test_base(trafo):
     molecule = tq.chemistry.Molecule(
         backend="base",
         geometry="he 0.0 0.0 0.0",
+        units="angstrom",
         basis_set="whatever",
         transformation=trafo,
         one_body_integrals=obt,
@@ -93,14 +94,14 @@ def test_base(trafo):
 def test_prepare_reference(trafo):
     geometry = "Li 0.0 0.0 0.0\nH 0.0 0.0 1.5"
     basis_set = "sto-3g"
-    mol = tq.Molecule(geometry=geometry, basis_set=basis_set, transformation=trafo)
+    mol = tq.Molecule(geometry=geometry, units="angstrom", basis_set=basis_set, transformation=trafo)
     H = mol.make_hamiltonian()
     U = mol.prepare_reference()
     E = tq.ExpectationValue(H=H, U=U)
     energy = tq.simulate(E)
     hf_energy = mol.compute_energy("hf")
     assert numpy.isclose(energy, hf_energy, atol=1.0e-4)
-    mol = tq.Molecule(geometry=geometry, basis_set=basis_set, transformation="reordered" + trafo)
+    mol = tq.Molecule(geometry=geometry, units="angstrom", basis_set=basis_set, transformation="reordered" + trafo)
     H = mol.make_hamiltonian()
     U = mol.prepare_reference()
     E = tq.ExpectationValue(H=H, U=U)
@@ -112,9 +113,9 @@ def test_prepare_reference(trafo):
 def test_orbital_types():
     geometry = "H 0.0 0.0 0.0\nH 0.0 0.0 2.0\nH 0.0 0.0 4.0\nH 0.0 0.0 6.0"
 
-    mol1 = tq.Molecule(geometry=geometry, basis_set="sto-3g")
-    mol2 = tq.Molecule(geometry=geometry, basis_set="sto-3g", orbital_type="hf")
-    mol3 = tq.Molecule(geometry=geometry, basis_set="sto-3g", orbital_type="native")
+    mol1 = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g")
+    mol2 = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", orbital_type="hf")
+    mol3 = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", orbital_type="native")
 
     energy = mol1.compute_energy("fci")
     for mol in [mol1, mol2, mol3]:
@@ -126,9 +127,9 @@ def test_orbital_types():
     # test initialization
     geometry = "Be 0.0 0.0 0.0\nH 0.0 0.0 2.0\nH 0.0 0.0 1.5"
 
-    mol1 = tq.Molecule(geometry=geometry, basis_set="sto-3g")
-    mol2 = tq.Molecule(geometry=geometry, basis_set="sto-3g", orbital_type="hf")
-    mol3 = tq.Molecule(geometry=geometry, basis_set="sto-3g", orbital_type="native")
+    mol1 = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g")
+    mol2 = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", orbital_type="hf")
+    mol3 = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", orbital_type="native")
 
 
 @pytest.mark.skipif(condition=not HAS_PSI4, reason="you don't have psi4")
@@ -148,7 +149,7 @@ def test_orbital_types():
 )
 def test_transformations(trafo_args):
     geomstring = "H 0.0 0.0 0.0\nH 0.0 0.0 0.7"
-    molecule = tq.chemistry.Molecule(geometry=geomstring, basis_set="sto-3g", **trafo_args)
+    molecule = tq.chemistry.Molecule(geometry=geomstring, units="angstrom", basis_set="sto-3g", **trafo_args)
     gs = numpy.linalg.eigvalsh(molecule.make_hamiltonian().to_matrix())[0]
     assert numpy.isclose(gs, -1.1361894540879054)
 
@@ -161,7 +162,7 @@ def test_dependencies():
 
 @pytest.mark.skipif(condition=not HAS_PSI4 and not HAS_PYSCF, reason="no quantum chemistry backends installed")
 def test_interface():
-    molecule = tq.chemistry.Molecule(basis_set="sto-3g", geometry="data/h2.xyz", transformation="JordanWigner")
+    molecule = tq.chemistry.Molecule(basis_set="sto-3g", geometry="data/h2.xyz", units="angstrom", transformation="JordanWigner")
 
 
 @pytest.mark.skipif(condition=not HAS_PSI4, reason="you don't have psi4")
@@ -175,7 +176,7 @@ def test_h2_hamiltonian_psi4():
 
 
 def do_test_h2_hamiltonian(qc_interface):
-    parameters = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", basis_set="sto-3g")
+    parameters = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g")
     H = qc_interface(parameters=parameters).make_hamiltonian().to_matrix()
     vals = numpy.linalg.eigvalsh(H)
     assert numpy.isclose(vals[0], -1.1368354639104123, atol=1.0e-4)
@@ -192,7 +193,7 @@ def do_test_h2_hamiltonian(qc_interface):
 def test_ucc_psi4(trafo, backend):
     if backend == "symbolic":
         pytest.skip("skipping for symbolic simulator  ... way too slow")
-    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", basis_set="sto-3g")
+    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g")
     do_test_ucc(
         qc_interface=qc.QuantumChemistryPsi4,
         parameters=parameters_qc,
@@ -204,7 +205,7 @@ def test_ucc_psi4(trafo, backend):
 
 @pytest.mark.skipif(condition=not HAS_PSI4, reason="you don't have psi4")
 def test_ucc_singles_psi4():
-    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", basis_set="6-31G")
+    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="6-31G")
     # default backend is fine
     # will not converge if singles are not added
     do_test_ucc(
@@ -232,7 +233,7 @@ def do_test_ucc(qc_interface, parameters, result, trafo, backend="qulacs"):
 def test_mp2_psi4():
     # the number might be wrong ... its definetely not what psi4 produces
     # however, no reason to expect projected MP2 is the same as UCC with MP2 amplitudes
-    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", basis_set="sto-3g")
+    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g")
     do_test_mp2(qc_interface=qc.QuantumChemistryPsi4, parameters=parameters_qc, result=-1.1344497203826904)
 
 
@@ -258,7 +259,7 @@ def test_amplitudes_psi4(method):
     results = {"mp2": -1.1279946983462537, "cc2": -1.1344484090805054, "ccsd": None, "cc3": None}
     # the number might be wrong ... its definitely not what psi4 produces
     # however, no reason to expect projected MP2 is the same as UCC with MP2 amplitudes
-    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", basis_set="sto-3g")
+    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g")
     do_test_amplitudes(
         method=method, qc_interface=qc.QuantumChemistryPsi4, parameters=parameters_qc, result=results[method]
     )
@@ -285,7 +286,7 @@ def do_test_amplitudes(method, qc_interface, parameters, result):
 @pytest.mark.parametrize("method", ["mp2", "mp3", "mp4", "cc2", "cc3", "ccsd", "ccsd(t)", "cisd", "cisdt"])
 def test_energies_psi4(method):
     # mp3 needs C1 symmetry
-    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", basis_set="6-31g")
+    parameters_qc = tequila.quantumchemistry.chemistry_tools.ParametersQC(geometry="data/h2.xyz", units="angstrom", basis_set="6-31g")
     if method in ["mp3", "mp4"]:
         psi4_interface = qc.QuantumChemistryPsi4(parameters=parameters_qc, point_group="c1")
     else:
@@ -297,9 +298,9 @@ def test_energies_psi4(method):
 
 @pytest.mark.skipif(condition=not HAS_PSI4, reason="psi4 not found")
 def test_restart_psi4():
-    h2 = tq.chemistry.Molecule(geometry="data/h2.xyz", basis_set="6-31g")
+    h2 = tq.chemistry.Molecule(geometry="data/h2.xyz", units="angstrom", basis_set="6-31g")
     wfn = h2.logs["hf"].wfn
-    h2x = tq.chemistry.Molecule(geometry="data/h2x.xyz", basis_set="6-31g", guess_wfn=wfn)
+    h2x = tq.chemistry.Molecule(geometry="data/h2x.xyz", units="angstrom", basis_set="6-31g", guess_wfn=wfn)
     wfnx = h2x.logs["hf"].wfn
     # new psi4 version changed printout
     # can currently only test if it does not crash (no guarantee that it actually read in)
@@ -313,7 +314,7 @@ def test_restart_psi4():
 
     wfnx.to_file("data/test_wfn.npy")
     h2 = tq.chemistry.Molecule(
-        geometry="data/h2.xyz", basis_set="6-31g", name="data/andreasdorn", guess_wfn="data/test_wfn.npy"
+        geometry="data/h2.xyz", units="angstrom", basis_set="6-31g", name="data/andreasdorn", guess_wfn="data/test_wfn.npy"
     )
     # with open(h2.logs['hf'].filename, "r") as f:
     #     found = False
@@ -327,7 +328,7 @@ def test_restart_psi4():
 @pytest.mark.skipif(condition=not HAS_PSI4, reason="psi4 not found")
 @pytest.mark.parametrize("active", [{"A1": [2, 3]}, {"B2": [0], "B1": [0]}, {"A1": [0, 1, 2, 3]}, {"B1": [0]}])
 def test_psi4_active_spaces(active):
-    mol = tq.chemistry.Molecule(geometry="data/h2o.xyz", basis_set="sto-3g", active_orbitals=active)
+    mol = tq.chemistry.Molecule(geometry="data/h2o.xyz", units="angstrom", basis_set="sto-3g", active_orbitals=active)
     H = mol.make_hamiltonian()
     Uhf = mol.prepare_reference()
     hf = tequila.simulators.simulator_api.simulate(tq.ExpectationValue(U=Uhf, H=H))
@@ -345,7 +346,7 @@ def test_rdms_psi4():
             [[[0.0, 0.0], [0.0, 0.0]], [[-0.21275021, 0.0], [0.0, 0.02289338]]],
         ]
     )
-    mol = qc.Molecule(geometry="data/h2.xyz", basis_set="sto-3g", backend="psi4", transformation="jordan-wigner")
+    mol = qc.Molecule(geometry="data/h2.xyz", units="angstrom", basis_set="sto-3g", backend="psi4", transformation="jordan-wigner")
     # Check matrices by psi4
     mol.compute_rdms(
         U=None, psi4_method="detci", psi4_options={"detci__ex_level": 2, "detci__opdm": True, "detci__tpdm": True}
@@ -359,7 +360,7 @@ def test_rdms_psi4():
 @pytest.mark.parametrize("geometry", ["H 0.0 0.0 0.0\nH 0.0 0.0 0.7"])
 @pytest.mark.parametrize("trafo", tq.quantumchemistry.encodings.known_encodings())
 def test_upccgsd(geometry, trafo):
-    molecule = tq.chemistry.Molecule(geometry=geometry, basis_set="sto-3g", transformation=trafo)
+    molecule = tq.chemistry.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", transformation=trafo)
     if not molecule.supports_ucc():
         return
     energy = do_test_upccgsd(molecule)
@@ -371,7 +372,7 @@ def test_upccgsd(geometry, trafo):
 
 @pytest.mark.skipif(condition=not HAS_PSI4 and not HAS_PYSCF, reason="psi4 or pyscf not found")
 def test_upccgsd_singles():
-    molecule = tq.chemistry.Molecule(geometry="H 0.0 0.0 0.0\nH 0.0 0.0 0.7", basis_set="6-31G")
+    molecule = tq.chemistry.Molecule(geometry="H 0.0 0.0 0.0\nH 0.0 0.0 0.7", units="angstrom", basis_set="6-31G")
     H = molecule.make_hamiltonian()
     energy1 = numpy.linalg.eigvalsh(H.to_matrix())[0]
     energy2 = do_test_upccgsd(molecule)
@@ -410,7 +411,7 @@ def do_test_upccgsd(molecule, *args, **kwargs):
 @pytest.mark.parametrize("backend", tq.simulators.simulator_api.INSTALLED_SIMULATORS.keys())
 @pytest.mark.skipif(condition=not HAS_PSI4 and not HAS_PYSCF, reason="psi4/pyscf not found")
 def test_hamiltonian_reduction(backend):
-    mol = tq.chemistry.Molecule(geometry="H 0.0 0.0 0.0\nH 0.0 0.0 0.7", basis_set="6-31G")
+    mol = tq.chemistry.Molecule(geometry="H 0.0 0.0 0.0\nH 0.0 0.0 0.7", units="angstrom", basis_set="6-31G")
     hf = mol.compute_energy("hf")
     U = mol.prepare_reference()
     H = mol.make_hamiltonian()
@@ -428,7 +429,7 @@ def test_hamiltonian_reduction(backend):
     "trafo", ["jordan_wigner", "bravyi_kitaev", "reordered_jordan_wigner", "TaperedBinary", "REORDEREDTAPEREDBINARY"]
 )
 def test_fermionic_gates(assume_real, trafo):
-    mol = tq.chemistry.Molecule(geometry="H 0.0 0.0 0.7\nLi 0.0 0.0 0.0", basis_set="sto-3g", transformation=trafo)
+    mol = tq.chemistry.Molecule(geometry="H 0.0 0.0 0.7\nLi 0.0 0.0 0.0", units="angstrom", basis_set="sto-3g", transformation=trafo)
     U1 = mol.prepare_reference()
     U2 = mol.prepare_reference()
     variable_count = {}
@@ -483,6 +484,7 @@ def test_hcb(trafo):
     geomstring = "Be 0.0 0.0 0.0\n H 0.0 0.0 1.6\n H 0.0 0.0 -1.6"
     mol1 = tq.Molecule(
         geometry=geomstring,
+        units="angstrom",
         active_orbitals=[1, 2, 3, 4, 5, 6],
         basis_set="sto-3g",
         transformation="ReorderedJordanWigner",
@@ -495,7 +497,7 @@ def test_hcb(trafo):
     assert numpy.isclose(energy1, -15.527740838656282, atol=1.0e-3)
 
     mol2 = tq.Molecule(
-        geometry=geomstring, active_orbitals=[1, 2, 3, 4, 5, 6], basis_set="sto-3g", transformation=trafo
+        geometry=geomstring, units="angstrom", active_orbitals=[1, 2, 3, 4, 5, 6], basis_set="sto-3g", transformation=trafo
     )
     H = mol2.make_hamiltonian()
     U = mol2.make_upccgsd_ansatz(name="UpCCGD", hcb_optimization=False)
@@ -517,7 +519,7 @@ def test_hcb(trafo):
 )
 @pytest.mark.parametrize("basis_set", ["sto-3g"])
 def test_pyscf_methods(method, geometry, basis_set):
-    mol = tq.Molecule(geometry=geometry, basis_set=basis_set, backend="psi4")
+    mol = tq.Molecule(geometry=geometry, units="angstrom", basis_set=basis_set, backend="psi4")
 
     e1 = mol.compute_energy(method=method)
     mol = tq.MoleculeFromTequila(mol=mol, backend="pyscf")
@@ -525,7 +527,7 @@ def test_pyscf_methods(method, geometry, basis_set):
     e2 = mol.compute_energy(method)
     assert numpy.isclose(e1, e2, atol=1.0e-4)
 
-    mol = tq.Molecule(geometry=geometry, basis_set=basis_set, backend="pyscf")
+    mol = tq.Molecule(geometry=geometry, units="angstrom", basis_set=basis_set, backend="pyscf")
     e3 = mol.compute_energy(method)
     assert numpy.isclose(e1, e3, atol=1.0e-4)
 
@@ -540,7 +542,7 @@ def test_pyscf_methods(method, geometry, basis_set):
     ],
 )
 def test_wfn_fci(geometry):
-    mol = tq.Molecule(geometry=geometry, basis_set="sto-3g", backend="pyscf")
+    mol = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", backend="pyscf")
     H = mol.make_hamiltonian()
     v, vv = numpy.linalg.eigh(H.to_matrix())
 
@@ -559,7 +561,7 @@ def test_wfn_fci(geometry):
 def test_orbital_optimization():
     from tequila.quantumchemistry import optimize_orbitals
 
-    mol = tq.Molecule(geometry="Li 0.0 0.0 0.0\nH 0.0 0.0 3.0", basis_set="STO-3G")
+    mol = tq.Molecule(geometry="Li 0.0 0.0 0.0\nH 0.0 0.0 3.0", units="angstrom", basis_set="STO-3G")
 
     circuit = mol.make_upccgsd_ansatz(name="UpCCGD")
     mol2 = optimize_orbitals(molecule=mol, circuit=circuit).molecule
@@ -573,7 +575,7 @@ def test_orbital_optimization():
 
 @pytest.mark.skipif(condition=not HAS_PYSCF, reason="pyscf not found")
 def test_orbital_transformation():
-    mol0 = tq.Molecule(geometry="Li 0.0 0.0 0.0\nH 0.0 0.0 0.75", basis_set="STO-3G", frozen_core=False)
+    mol0 = tq.Molecule(geometry="Li 0.0 0.0 0.0\nH 0.0 0.0 0.75", units="angstrom", basis_set="STO-3G", frozen_core=False)
     mol0.print_basis_info()
     mol1 = mol0.orthonormalize_basis_orbitals()
 
@@ -611,9 +613,9 @@ def test_orbital_transformation():
 @pytest.mark.parametrize("core", [[], [0], [0, 1]])
 @pytest.mark.skipif(condition=not HAS_PSI4 and not HAS_PYSCF, reason="psi4/pyscf not found")
 def test_native_active_space(system, core):
-    mol = tq.Molecule(geometry=system, basis_set="sto-3g", frozen_core=False, frozen_orbitals=core)
+    mol = tq.Molecule(geometry=system, units="angstrom", basis_set="sto-3g", frozen_core=False, frozen_orbitals=core)
     eival, eivect = numpy.linalg.eigh(mol.make_hamiltonian().to_matrix())
-    mol = tq.Molecule(geometry=system, basis_set="sto-3g", frozen_core=False).use_native_orbitals(core=core)
+    mol = tq.Molecule(geometry=system, units="angstrom", basis_set="sto-3g", frozen_core=False).use_native_orbitals(core=core)
     eival1, eivect1 = numpy.linalg.eigh(mol.make_hamiltonian().to_matrix())
     assert numpy.allclose(eival, eival1)
 
@@ -622,8 +624,8 @@ def test_native_active_space(system, core):
 @pytest.mark.skipif(condition=not HAS_PSI4, reason="psi4 not found")
 def test_crosscheck_mp2():
     # Be has issues with degeneracies and ordering (t1-t2 is not necessarily 0)
-    mol1 = tq.Molecule(geometry="he 0.0 0.0 0.0", basis_set="6-31G", backend="psi4")
-    mol2 = tq.Molecule(geometry="he 0.0 0.0 0.0", basis_set="6-31G", backend="pyscf")
+    mol1 = tq.Molecule(geometry="he 0.0 0.0 0.0", units="angstrom", basis_set="6-31G", backend="psi4")
+    mol2 = tq.Molecule(geometry="he 0.0 0.0 0.0", units="angstrom", basis_set="6-31G", backend="pyscf")
     t2_1, e1 = mol1.compute_mp2_amplitudes(return_energy=True)
     t2_2, e2 = mol2.compute_mp2_amplitudes(return_energy=True)
     assert numpy.isclose(e1, e2, atol=1.0e-4)
@@ -633,8 +635,8 @@ def test_crosscheck_mp2():
 @pytest.mark.skipif(condition=not HAS_PYSCF, reason="pyscf not found")
 @pytest.mark.skipif(condition=not HAS_PSI4, reason="psi4 not found")
 def test_crosscheck_cis():
-    mol1 = tq.Molecule(geometry="he 0.0 0.0 0.0", basis_set="6-31G", backend="psi4")
-    mol2 = tq.Molecule(geometry="he 0.0 0.0 0.0", basis_set="6-31G", backend="pyscf")
+    mol1 = tq.Molecule(geometry="he 0.0 0.0 0.0", units="angstrom", basis_set="6-31G", backend="psi4")
+    mol2 = tq.Molecule(geometry="he 0.0 0.0 0.0", units="angstrom", basis_set="6-31G", backend="pyscf")
     r_1 = mol1.compute_cis_amplitudes()
     r_2 = mol2.compute_cis_amplitudes()
     for i in range(len(r_1.omegas)):
@@ -648,8 +650,8 @@ def test_crosscheck_cis():
 @pytest.mark.skipif(condition=not HAS_PSI4, reason="psi4 not found")
 def test_crosscheck_cis_mp2_large():
     # only energies (degeneracies: orbitals change places)
-    mol1 = tq.Molecule(geometry="be 0.0 0.0 0.0", basis_set="6-31G", backend="psi4")
-    mol2 = tq.Molecule(geometry="be 0.0 0.0 0.0", basis_set="6-31G", backend="pyscf")
+    mol1 = tq.Molecule(geometry="be 0.0 0.0 0.0", units="angstrom", basis_set="6-31G", backend="psi4")
+    mol2 = tq.Molecule(geometry="be 0.0 0.0 0.0", units="angstrom", basis_set="6-31G", backend="pyscf")
     r_1 = mol1.compute_cis_amplitudes()
     r_2 = mol2.compute_cis_amplitudes()
     for i in range(len(r_1.omegas)):
@@ -669,14 +671,14 @@ def test_spa_ansatz_be():
     print(not HAS_PSI4 and not HAS_PYSCF)
     edges = [(0,), (1, 2, 3, 4)]
     # doing without frozen-core to test explicitly if single-orbital pairs work
-    mol = tq.Molecule(geometry="be 0.0 0.0 0.0", basis_set="sto-3g", transformation="BravyiKitaev", frozen_core=False)
+    mol = tq.Molecule(geometry="be 0.0 0.0 0.0", units="angstrom", basis_set="sto-3g", transformation="BravyiKitaev", frozen_core=False)
     H = mol.make_hamiltonian()
     U = mol.make_ansatz(name="SPA", edges=edges)
     E = tq.ExpectationValue(H=H, U=U)
     result = tq.minimize(E, silent=True)
     energy = result.energy
 
-    mol = tq.Molecule(geometry="be 0.0 0.0 0.0", basis_set="sto-3g", frozen_core=False)
+    mol = tq.Molecule(geometry="be 0.0 0.0 0.0", units="angstrom", basis_set="sto-3g", frozen_core=False)
     H = mol.make_hamiltonian()
     U0 = mol.make_ansatz(name="SPA", edges=edges)
     U1 = mol.make_ansatz(name="SPA", ladder=False, edges=edges)
@@ -700,7 +702,7 @@ def test_spa_ansatz_be():
 @pytest.mark.parametrize("transformation", tq.quantumchemistry.encodings.known_encodings())
 @pytest.mark.skipif(condition=not HAS_PSI4 and not HAS_PYSCF, reason="psi4/pyscf not found")
 def test_spa_consistency(geometry, name, optimize, transformation):
-    mol = tq.Molecule(geometry=geometry, basis_set="sto-3g", transformation=transformation).use_native_orbitals()
+    mol = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", transformation=transformation).use_native_orbitals()
 
     # test compares HCB and non-HCB SPA implementations
     # conversion needs to be implemented for comparisson
@@ -740,7 +742,7 @@ def test_spa_consistency(geometry, name, optimize, transformation):
 def test_variable_consistency():
     geometry = "H 0.0 0.0 0.0\nH 0.0 0.0 1.0\nH 0.0 0.0 2.0\nH 0.0 0.0 3.0"
     mol = tq.Molecule(
-        geometry=geometry, basis_set="sto-3g", transformation="ReorderedJordanWigner"
+        geometry=geometry, units="angstrom", basis_set="sto-3g", transformation="ReorderedJordanWigner"
     ).use_native_orbitals()
     U = mol.make_ansatz("SPA", edges=[(0, 1), (2, 3)])
     variables = {k: 1.0 for k in U.extract_variables()}
@@ -754,7 +756,7 @@ def test_variable_consistency():
     E = tq.ExpectationValue(H=H, U=U)
     E2 = tq.simulate(E, variables=variables)
 
-    mol = tq.Molecule(geometry=geometry, basis_set="sto-3g", transformation="JordanWigner").use_native_orbitals()
+    mol = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", transformation="JordanWigner").use_native_orbitals()
     U = mol.make_ansatz("SPA", edges=[(0, 1), (2, 3)])
     H = mol.make_hamiltonian(condensed=False)
     E = tq.ExpectationValue(H=H, U=U)
@@ -779,7 +781,7 @@ def test_variable_consistency():
 )
 @pytest.mark.parametrize("optimize", [True, False])
 def test_hcb_rdms(geometry, optimize):
-    mol1 = tq.Molecule(geometry=geometry, basis_set="sto-3g", transformation="ReorderedJordanWigner")
+    mol1 = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g", transformation="ReorderedJordanWigner")
     H = mol1.make_hamiltonian()
     HCB = mol1.make_hardcore_boson_hamiltonian()
 
@@ -824,7 +826,7 @@ def test_hcb_rdms(geometry, optimize):
 @pytest.mark.skipif(condition=not HAS_PYSCF, reason="you don't have pyscf")
 @pytest.mark.parametrize("geometry", ["Li 0.0 0.0 0.0\nH 0.0 0.0 3.0", "Be 0.0 0.0 0.0\nH 0.0 0.0 3.0\nH 0.0 0.0 -3.0"])
 def test_orbital_optimization_hcb(geometry):
-    mol = tq.Molecule(geometry=geometry, basis_set="sto-3g")
+    mol = tq.Molecule(geometry=geometry, units="angstrom", basis_set="sto-3g")
 
     if mol.n_electrons == 4:
         edges = [(0, 2, 5), (1, 3, 4)]
@@ -879,6 +881,7 @@ def test_givens_on_molecule(size, transformation):
     # original molecule/H
     mol = tq.Molecule(
         geometry="He 0.0 0.0 0.0",
+        units="angstrom",
         nuclear_repulsion=0.0,
         one_body_integrals=h,
         two_body_integrals=g,
@@ -889,6 +892,7 @@ def test_givens_on_molecule(size, transformation):
     # transformed molecule/H
     tmol = tq.Molecule(
         geometry="He 0.0 0.0 0.0",
+        units="angstrom",
         nuclear_repulsion=0.0,
         one_body_integrals=th,
         two_body_integrals=tg,
@@ -933,6 +937,7 @@ def test_givens_on_molecule():
     # original molecule/H
     mol = tq.Molecule(
         geometry="He 0.0 0.0 0.0",
+        units="angstrom",
         nuclear_repulsion=0.0,
         one_body_integrals=h,
         two_body_integrals=g,
@@ -943,6 +948,7 @@ def test_givens_on_molecule():
     # transformed molecule/H
     tmol = tq.Molecule(
         geometry="He 0.0 0.0 0.0",
+        units="angstrom",
         nuclear_repulsion=0.0,
         one_body_integrals=th,
         two_body_integrals=tg,

--- a/tests/test_chemistry_f12.py
+++ b/tests/test_chemistry_f12.py
@@ -11,7 +11,9 @@ HAS_PSI4 = "psi4" in tq.quantumchemistry.INSTALLED_QCHEMISTRY_BACKENDS
 def test_correction_psi4_active():
     geomstring = "He 0.0 0.0 0.0"
     # This active space does not need to make sense
-    mol = tq.Molecule(geometry=geomstring, units="angstrom", basis_set="cc-pvqz", active_orbitals={"AG": [0, 1], "B1U": [0, 1]})
+    mol = tq.Molecule(
+        geometry=geomstring, units="angstrom", basis_set="cc-pvqz", active_orbitals={"AG": [0, 1], "B1U": [0, 1]}
+    )
     rdminfo = {"rdm__psi4_method": "detci"}
     dE = mol.perturbative_f12_correction(cabs_type="active", **rdminfo)
 
@@ -34,7 +36,13 @@ def test_correction_psi4_cabsplus():
     # Try to run CABS+, which as of now is only available via direct installation of personal fork
     # Choice of CABS also not sensible here
     geomstring = "He 0.0 0.0 0.0"
-    mol = tq.Molecule(geometry=geomstring, units="angstrom", basis_set="cc-pvdz", active_orbitals=[i for i in range(2)], point_group="c1")
+    mol = tq.Molecule(
+        geometry=geomstring,
+        units="angstrom",
+        basis_set="cc-pvdz",
+        active_orbitals=[i for i in range(2)],
+        point_group="c1",
+    )
     rdminfo = {"rdm__psi4_method": "detci"}
     cabs_options = {"cabs_name": "cc-pvqz"}
     dE = mol.perturbative_f12_correction(cabs_type="cabs+", cabs_options=cabs_options, **rdminfo)

--- a/tests/test_chemistry_f12.py
+++ b/tests/test_chemistry_f12.py
@@ -11,7 +11,7 @@ HAS_PSI4 = "psi4" in tq.quantumchemistry.INSTALLED_QCHEMISTRY_BACKENDS
 def test_correction_psi4_active():
     geomstring = "He 0.0 0.0 0.0"
     # This active space does not need to make sense
-    mol = tq.Molecule(geometry=geomstring, basis_set="cc-pvqz", active_orbitals={"AG": [0, 1], "B1U": [0, 1]})
+    mol = tq.Molecule(geometry=geomstring, units="angstrom", basis_set="cc-pvqz", active_orbitals={"AG": [0, 1], "B1U": [0, 1]})
     rdminfo = {"rdm__psi4_method": "detci"}
     dE = mol.perturbative_f12_correction(cabs_type="active", **rdminfo)
 
@@ -34,7 +34,7 @@ def test_correction_psi4_cabsplus():
     # Try to run CABS+, which as of now is only available via direct installation of personal fork
     # Choice of CABS also not sensible here
     geomstring = "He 0.0 0.0 0.0"
-    mol = tq.Molecule(geometry=geomstring, basis_set="cc-pvdz", active_orbitals=[i for i in range(2)], point_group="c1")
+    mol = tq.Molecule(geometry=geomstring, units="angstrom", basis_set="cc-pvdz", active_orbitals=[i for i in range(2)], point_group="c1")
     rdminfo = {"rdm__psi4_method": "detci"}
     cabs_options = {"cabs_name": "cc-pvqz"}
     dE = mol.perturbative_f12_correction(cabs_type="cabs+", cabs_options=cabs_options, **rdminfo)
@@ -59,6 +59,7 @@ def test_correction_madness(trafo):
     mol = tq.Molecule(
         name="data/f12/he-f12",
         geometry=geomstring,
+        units="angstrom",
         basis_set="madness",
         n_pno="read",
         active_orbitals=[0, 1],

--- a/tests/test_chemistry_madness.py
+++ b/tests/test_chemistry_madness.py
@@ -30,7 +30,7 @@ def test_executable():
 def test_madness_he_data():
     # relies that he_xtensor.npy are present (x=g,h)
     geomstring = "He 0.0 0.0 0.0"
-    molecule = tq.Molecule(name="he", geometry=geomstring)
+    molecule = tq.Molecule(name="he", geometry=geomstring, units="angstrom")
     H = molecule.make_hamiltonian()
     UHF = molecule.prepare_reference()
     EHF = tq.simulate(tq.ExpectationValue(H=H, U=UHF))
@@ -44,7 +44,7 @@ def test_madness_he_data():
 
 @pytest.mark.skipif(executable is None, reason="madness was not found")
 def test_madness_frozen_core():
-    molecule = tq.Molecule(geometry="Li 0.0 0.0 0.0\nLi 0.0 0.0 1.6")
+    molecule = tq.Molecule(geometry="Li 0.0 0.0 0.0\nLi 0.0 0.0 1.6", units="angstrom")
     assert molecule.n_orbitals == 2
     assert molecule.parameters.get_number_of_core_electrons() == 4
 
@@ -54,7 +54,7 @@ def test_madness_full_he():
     # relies on madness being compiled and MAD_ROOT_DIR exported
     # or pno_integrals in the path
     geomstring = "He 0.0 0.0 0.0"
-    molecule = tq.Molecule(geometry=geomstring, n_pno=1)
+    molecule = tq.Molecule(geometry=geomstring, n_pno=1, units="angstrom")
     H = molecule.make_hamiltonian()
     UHF = molecule.prepare_reference()
     EHF = tq.simulate(tq.ExpectationValue(H=H, U=UHF))
@@ -67,14 +67,14 @@ def test_madness_full_he():
 
 @pytest.mark.skipif(executable is None, reason="madness was not found")
 def test_madness_data_io():
-    mol = tq.Molecule(geometry="he 0.0 0.0 0.0")
-    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", n_pno="read")
+    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", units="angstrom")
+    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", n_pno="read", units="angstrom")
 
-    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", datadir="1/2/3")
-    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", datadir="1/2/3", n_pno="read")
+    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", datadir="1/2/3", units="angstrom")
+    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", datadir="1/2/3", n_pno="read", units="angstrom")
 
-    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", datadir="1/2/3", name="asd")
-    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", datadir="1/2/3", name="asd", n_pno="read")
+    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", datadir="1/2/3", name="asd", units="angstrom")
+    mol = tq.Molecule(geometry="he 0.0 0.0 0.0", datadir="1/2/3", name="asd", n_pno="read", units="angstrom")
 
 
 @pytest.mark.skipif(executable is None, reason="madness was not found")
@@ -83,7 +83,7 @@ def test_madness_full_li_plus():
     # or pno_integrals in the path
     geomstring = "Li 0.0 0.0 0.0"
     molecule = tq.Molecule(
-        name="li+", geometry=geomstring, n_pno=1, charge=1, frozen_core=False
+        name="li+", geometry=geomstring, units="angstrom", n_pno=1, charge=1, frozen_core=False
     )  # need to deactivate frozen_core, otherwise there is no active orbital
     H = molecule.make_hamiltonian()
     UHF = molecule.prepare_reference()
@@ -100,7 +100,7 @@ def test_madness_full_be():
     # relies on madness being compiled and MAD_ROOT_DIR exported
     # or pno_integrals in the path
     geomstring = "Be 0.0 0.0 0.0"
-    molecule = tq.Molecule(name="be", geometry=geomstring, n_pno=3, frozen_core=True)
+    molecule = tq.Molecule(name="be", geometry=geomstring, units="angstrom", n_pno=3, frozen_core=True)
     H = molecule.make_hamiltonian()
     UHF = molecule.prepare_reference()
     EHF = tq.simulate(tq.ExpectationValue(H=H, U=UHF))
@@ -125,6 +125,7 @@ def test_madness_upccgsd(trafo):
         name="balanced_be",
         frozen_core=False,
         geometry="Be 0.0 0.0 0.0",
+        units="angstrom",
         n_pno=n_pno,
         pno={"diagonal": True, "maxrank": 1},
         transformation=trafo,
@@ -205,6 +206,7 @@ def test_madness_pyscf_bridge():
     mol = tq.Molecule(
         name="balanced_be",
         geometry="Be 0.0 0.0 0.0",
+        units="angstrom",
         n_pno=2,
         pno={"diagonal": True, "maxrank": 1},
     )


### PR DESCRIPTION
subsequently allows for the initialization of a quantum chemistry base object with a molecular geometry in bohr. usage with angstrom should be completely unchanged if I didn't miss anything, except for a warning if no unit is specified during initialization of a molecule.