### PR TITLE
Small fixes for Identity and GlobalPhase gates

### DIFF
--- a/src/tequila/circuit/circuit.py
+++ b/src/tequila/circuit/circuit.py
@@ -63,6 +63,9 @@ class QCircuit:
         moms = []
         moms.append(Moment())
         for g in self.gates:
+            if not g.qubits:
+                continue
+
             qus = g.qubits
             spots = [table[q] for q in qus]
 

--- a/src/tequila/circuit/gates.py
+++ b/src/tequila/circuit/gates.py
@@ -89,13 +89,12 @@ def I(
     target: typing.Union[list, int], control: typing.Union[list, int] = None, power=None, angle=None, *args, **kwargs
 ) -> QCircuit:
     """
-    This function provides a primitive implementation of the identity gate as a place
-    holder gate with no physical effect.
-    The user can add this gate into the circuit and get it also when
-    calling functions regarding the circuit's stats (i.e. gates included)
+    A gate that has no effect, but can be used to mark a qubit as being used.
+    This can for example be useful if a qubit is only being used in some variants
+    of a circuit, but you want to prevent the output format from changing.
     """
-    # zero generator for a no-operation gate
-    generator = lambda q: 0
+    # Ugly workaround, we can't simply use paulis.Zero() because this wouldn't mark the qubit as being used.
+    generator = lambda q: 0 * paulis.X(q)
     return _initialize_power_gate(
         name="I", power=power, angle=angle, target=target, control=control, generator=generator, *args, **kwargs
     )


### PR DESCRIPTION
The following two code snippets are fixed by this pull request:
```python
U = tq.gates.I(target=0)
U.map_qubits({0: 1})
```

```python
U = tq.gates.GlobalPhase(angle=1)
U.depth
```