### PR TITLE
Reimplement QCircuit to_matrix function using Tequila simulate

### DIFF
--- a/.github/workflows/ci_backends.yml
+++ b/.github/workflows/ci_backends.yml
@@ -96,5 +96,4 @@ jobs:
         pytest -m "not dependencies" tests/test_scipy.py --slow
         pytest -m "not dependencies" tests/test_gd_optimizer.py --slow
         pytest -m "not dependencies" tests/test_mappings.py --slow
-        pip install "quimb"
         pytest -m "not dependencies" tests/test_circuit_unitary.py --slow

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ qulacs # default simulator (best integration), remove if the installation gives 
 #pyquil<3.0 # you also need to install the forest-sdk
 #qulacs-gpu # you can't have qulacs and qulacs-gpu at the same time
 #qibo <= 0.1.1 # can not be installed in the same environment as gpyopt
-#quimb
 #mqt.ddsim == 2.0.0b2  # requires qiskit < 2
 
 #optional optimizers

--- a/src/tequila/circuit/circuit.py
+++ b/src/tequila/circuit/circuit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from tequila.circuit._gates_impl import QGateImpl, assign_variable, list_assignment, GlobalPhaseGateImpl, PhaseGateImpl
 from tequila.utils.exceptions import TequilaException, TequilaWarning
-from tequila.utils.bitstrings import BitNumbering
+from tequila.utils.bitstrings import BitNumbering, reverse_int_bits
 import typing
 import copy
 from collections import defaultdict
@@ -449,7 +449,7 @@ class QCircuit:
         else:
             return QCircuit(gates=[gate])
 
-    def to_matrix(self, variables=None):
+    def to_matrix(self, variables=None, numbering: BitNumbering = BitNumbering.MSB, backend: str = None):
         """
         take the circuit and return the unitary matrix corresponding to it.
         Parameters
@@ -464,60 +464,31 @@ class QCircuit:
         np.ndarray:
             the unitary matrix corresponding to the circuit.
         """
-        import quimb.gates
-        import quimb.tensor as qtn
-        from tequila import compile_circuit
+        from tequila import format_variable_dictionary
+        from tequila.simulators.simulator_api import compile_circuit
 
-        num_variables = len(self.extract_variables())
+        variables = format_variable_dictionary(variables)
 
-        if num_variables == 0:
-            variables = {}
-        elif variables is None:
+        if variables is None and not (len(self.extract_variables()) == 0):
             raise TequilaException(
-                f"QCircuit.to_matrix(): no variables provided, but the circuit has {num_variables} variables"
+                "You called simulate for a parametrized type but forgot to pass down the variables: {}".format(
+                    self.extract_variables()
+                )
             )
 
-        compiled_circuit = compile_circuit(
-            self,
+        compiled = compile_circuit(
+            abstract_circuit=self,
+            variables=variables,
+            backend=backend,
         )
-        compiled_circuit = compiled_circuit.map_variables(variables)
 
-        gate_mapping = {"Rx": "RX", "Ry": "RY", "Rz": "RZ", "H": "H", "X": "X"}
+        columns = []
+        for i in range(2**self.n_qubits):
+            initial_state = reverse_int_bits(i, nbits=self.n_qubits) if numbering == BitNumbering.LSB else i
+            output = compiled.simulate(variables=variables, initial_state=initial_state).to_array(numbering, copy=False)
+            columns.append(output)
 
-        quimb_circuit = qtn.Circuit(self.n_qubits)
-
-        # quimb uses MSB convention, so we need to modify the qubit indices
-        # to LSB
-        for g in compiled_circuit.gates:
-            if g.name not in gate_mapping:
-                raise TequilaException(
-                    f"Gate {g.name} is not supported for conversion to matrix. "
-                    f"Supported gates: {list(gate_mapping.keys())}"
-                )
-
-            if g.is_parameterized():
-                quimb_circuit.apply_gate(
-                    gate_mapping[g.name],
-                    params=[float(g.parameter())],
-                    qubits=[abs(t - self.n_qubits + 1) for t in list(g.target)],
-                    parameterize=True,
-                )
-            elif g.is_controlled():
-                quimb_circuit.apply_gate(
-                    gate_mapping[g.name],
-                    qubits=[abs(t - self.n_qubits + 1) for t in list(g.target)],
-                    controls=[abs(c - self.n_qubits + 1) for c in list(g.control)],
-                )
-            else:
-                quimb_circuit.apply_gate(
-                    gate_mapping[g.name],
-                    qubits=[abs(t - self.n_qubits + 1) for t in list(g.target)],
-                )
-
-        uni = quimb_circuit.get_uni()
-        unitary = np.array(uni.to_dense())
-
-        return unitary
+        return np.column_stack(columns)
 
     def to_networkx(self):
         """

--- a/tests/test_circuit_unitary.py
+++ b/tests/test_circuit_unitary.py
@@ -5,6 +5,7 @@ import tequila as tq
 import pytest
 import importlib
 
+from tequila import BitNumbering
 
 test_case = np.array(
     [
@@ -91,11 +92,7 @@ test_case = np.array(
     ]
 )
 
-# Check if quimb is installed
-HAS_QUIMB = importlib.util.find_spec("quimb") is not None
 
-
-@pytest.mark.skipif(condition=not HAS_QUIMB, reason="quimb not installed")
 def test_circuit_to_matrix():
     """
     Test the conversion of a 3-qubit circuit to a unitary matrix.
@@ -103,13 +100,12 @@ def test_circuit_to_matrix():
     circuit = tq.gates.H(target=0) + tq.gates.CNOT(target=1, control=0) + tq.gates.CNOT(target=2, control=1)
 
     # Convert the circuit to a unitary matrix
-    unitary_matrix = circuit.to_matrix()
+    unitary_matrix = circuit.to_matrix(numbering=BitNumbering.LSB)
 
     # Compare with the expected result
     assert_almost_equal(unitary_matrix, test_case, decimal=8)
 
 
-@pytest.mark.skipif(condition=not HAS_QUIMB, reason="quimb not installed")
 def test_circuit_to_matrix_with_params():
     PM = np.kron(tq.paulis.Y(0).to_matrix(), tq.paulis.X(0).to_matrix())
     U = tq.gates.ExpPauli(paulistring="X(0)Y(1)", angle="a")
@@ -117,6 +113,6 @@ def test_circuit_to_matrix_with_params():
     N = 2**2
 
     for a in [1.0, 2.0, -1.0]:
-        UM1 = U.to_matrix({"a": a})
+        UM1 = U.to_matrix({"a": a}, numbering=BitNumbering.LSB)
         UM2 = np.cos(-a / 2) * np.eye(N) + 1.0j * np.sin(-a / 2) * PM
         assert_almost_equal(UM1, UM2)


### PR DESCRIPTION
Implements the `to_matrix` function of `QCircuit` directly using the Tequila simulate function.
This works with any Tequila circuit and removes the dependency on quimb.

It would be interesting to use some sort of batched simulate function which runs the simulation on all basis states at once and might be faster. I have not looked into whether this exists and how much performance improvement it would bring.