### PR TITLE
Use `up_to_phase = True` with gridsynth

### DIFF
--- a/src/tequila/circuit/compiler.py
+++ b/src/tequila/circuit/compiler.py
@@ -1111,16 +1111,16 @@ def compile_pauli_rotations(gate: QGateImpl, epsilon: float, pauli_dict: dict) -
             for g in reversed(gates):
                 match g:
                     case "X":
-                        result += X(target=gate.target)
+                        result += X(target=0)
                         v = v[::-1]
                     case "H":
-                        result += H(target=gate.target)
+                        result += H(target=0)
                         v = H_mat @ v
                     case "S":
-                        result += S(target=gate.target)
+                        result += S(target=0)
                         v[1] *= 1j
                     case "T":
-                        result += T(target=gate.target)
+                        result += T(target=0)
                         v[1] *= T_val
                     case c:
                         raise ValueError(f"Got unexpected gate {c}")
@@ -1128,6 +1128,8 @@ def compile_pauli_rotations(gate: QGateImpl, epsilon: float, pauli_dict: dict) -
             global_phase = -rounded_parameter / 2 - numpy.angle(v[0])
             result += GlobalPhase(angle=global_phase)
             pauli_dict[bucket] = result
+
+        result = result.map_qubits({0: gate.target[0]})
 
         if gate.name.lower() in ["rx", "ry"]:
             result = H(target=gate.target) + result + H(target=gate.target)

--- a/src/tequila/circuit/compiler.py
+++ b/src/tequila/circuit/compiler.py
@@ -352,6 +352,10 @@ class CircuitCompiler:
             if self.ry_gate:
                 cg = compile_ry(gate=cg, controlled_rotation=self.controlled_rotation)
             if controlled:
+                if self.toffoli:
+                    cg = compile_toffoli(gate=cg)
+                    if self.phase:
+                        cg = compile_phase(gate=cg)
                 if self.cc_max or self.multicontrol:
                     cg = compile_to_single_control(gate=cg)
                 if self.controlled_exponential_pauli:
@@ -360,10 +364,6 @@ class CircuitCompiler:
                     cg = compile_controlled_power(gate=cg)
                 if self.controlled_phase:
                     cg = compile_controlled_phase(gate=cg)
-                    if self.phase:
-                        cg = compile_phase(gate=cg)
-                if self.toffoli:
-                    cg = compile_toffoli(gate=cg)
                     if self.phase:
                         cg = compile_phase(gate=cg)
                 if self.controlled_rotation:
@@ -607,7 +607,7 @@ def compile_toffoli(gate) -> QCircuit:
         A QCircuit; the result of compilation.
     """
 
-    if gate.name.lower != "x":
+    if not (gate.name.lower() == "x" and len(gate.control) == 2):
         return QCircuit.wrap_gate(gate)
     control = gate.control
     c1 = control[1]
@@ -1085,28 +1085,38 @@ def compile_pauli_rotations(gate: QGateImpl, epsilon: float) -> QCircuit:
     # to compile to a Clifford + T gateset. Compiling controlled rotations to uncontrolled ones
     # should be handled by other compiler passes.
     if gate.name.lower() in ["rx", "ry", "rz"] and not gate.is_controlled():
+        if abs(gate.parameter) < epsilon:
+            return QCircuit()
         if not isinstance(gate.parameter, numbers.Number):
             raise TequilaCompilerException("Can't compile parametrized rotations to Clifford + T gates")
         with warnings.catch_warnings():
             # Silence warning about using floats
             warnings.simplefilter(action="ignore", category=UserWarning, lineno=362)
-            gates = gridsynth_gates(theta=gate.parameter, epsilon=epsilon)
+            gates = gridsynth_gates(theta=gate.parameter, epsilon=epsilon, up_to_phase=True)
 
         result = QCircuit()
+        v = numpy.array([1, 0], dtype=complex)
+        H_mat = numpy.array([[1, 1], [1, -1]]) / numpy.sqrt(2)
+        T_val = numpy.exp(pi / 4 * 1j)
         for g in reversed(gates):
             match g:
-                case "W":
-                    result += GlobalPhase(angle=pi / 4)
                 case "X":
                     result += X(target=gate.target)
+                    v = v[::-1]
                 case "H":
                     result += H(target=gate.target)
+                    v = H_mat @ v
                 case "S":
                     result += S(target=gate.target)
+                    v[1] *= 1j
                 case "T":
                     result += T(target=gate.target)
+                    v[1] *= T_val
                 case c:
                     raise ValueError(f"Got unexpected gate {c}")
+
+        global_phase = -gate.parameter / 2 - numpy.angle(v[0])
+        result += GlobalPhase(angle=global_phase)
 
         if gate.name.lower() in ["rx", "ry"]:
             result = H(target=gate.target) + result + H(target=gate.target)

--- a/src/tequila/circuit/compiler.py
+++ b/src/tequila/circuit/compiler.py
@@ -315,6 +315,9 @@ class CircuitCompiler:
 
         compiled_gates = []
 
+        # Keep a dicitionary of compiled pauli_rotations
+        pauli_dict = {}
+
         for idx, gate in gatelist:
             cg = gate
             controlled = gate.is_controlled()
@@ -369,7 +372,7 @@ class CircuitCompiler:
                 if self.controlled_rotation:
                     cg = compile_controlled_rotation(gate=cg)
             if self.pauli_rotations:
-                cg = compile_pauli_rotations(gate=cg, epsilon=self.epsilon)
+                cg = compile_pauli_rotations(gate=cg, epsilon=self.epsilon, pauli_dict=pauli_dict)
 
             compiled_gates.append((idx, cg))
 
@@ -1063,7 +1066,7 @@ def compile_ch(gate: QGateImpl) -> QCircuit:
 
 
 @compiler
-def compile_pauli_rotations(gate: QGateImpl, epsilon: float) -> QCircuit:
+def compile_pauli_rotations(gate: QGateImpl, epsilon: float, pauli_dict: dict) -> QCircuit:
     """
     Compile uncontrolled Pauli rotations gates into Clifford + T gates.
 
@@ -1085,38 +1088,46 @@ def compile_pauli_rotations(gate: QGateImpl, epsilon: float) -> QCircuit:
     # to compile to a Clifford + T gateset. Compiling controlled rotations to uncontrolled ones
     # should be handled by other compiler passes.
     if gate.name.lower() in ["rx", "ry", "rz"] and not gate.is_controlled():
-        if abs(gate.parameter) < epsilon:
-            return QCircuit()
         if not isinstance(gate.parameter, numbers.Number):
             raise TequilaCompilerException("Can't compile parametrized rotations to Clifford + T gates")
-        with warnings.catch_warnings():
-            # Silence warning about using floats
-            warnings.simplefilter(action="ignore", category=UserWarning, lineno=362)
-            gates = gridsynth_gates(theta=gate.parameter, epsilon=epsilon, up_to_phase=True)
 
-        result = QCircuit()
-        v = numpy.array([1, 0], dtype=complex)
-        H_mat = numpy.array([[1, 1], [1, -1]]) / numpy.sqrt(2)
-        T_val = numpy.exp(pi / 4 * 1j)
-        for g in reversed(gates):
-            match g:
-                case "X":
-                    result += X(target=gate.target)
-                    v = v[::-1]
-                case "H":
-                    result += H(target=gate.target)
-                    v = H_mat @ v
-                case "S":
-                    result += S(target=gate.target)
-                    v[1] *= 1j
-                case "T":
-                    result += T(target=gate.target)
-                    v[1] *= T_val
-                case c:
-                    raise ValueError(f"Got unexpected gate {c}")
+        # Compute bucket by rounding to the next multiple of epsilon
+        bucket = int(numpy.round(gate.parameter / (2 * epsilon)))
+        rounded_parameter = bucket * (2 * epsilon)
+        if bucket in pauli_dict:
+            result = pauli_dict[bucket]
+        elif bucket == 0:
+            result = QCircuit()
+        else:
+            with warnings.catch_warnings():
+                # Silence warning about using floats
+                warnings.simplefilter(action="ignore", category=UserWarning, lineno=362)
+                gates = gridsynth_gates(theta=rounded_parameter, epsilon=epsilon, up_to_phase=True)
 
-        global_phase = -gate.parameter / 2 - numpy.angle(v[0])
-        result += GlobalPhase(angle=global_phase)
+            result = QCircuit()
+            v = numpy.array([1, 0], dtype=complex)
+            H_mat = numpy.array([[1, 1], [1, -1]]) / numpy.sqrt(2)
+            T_val = numpy.exp(pi / 4 * 1j)
+            for g in reversed(gates):
+                match g:
+                    case "X":
+                        result += X(target=gate.target)
+                        v = v[::-1]
+                    case "H":
+                        result += H(target=gate.target)
+                        v = H_mat @ v
+                    case "S":
+                        result += S(target=gate.target)
+                        v[1] *= 1j
+                    case "T":
+                        result += T(target=gate.target)
+                        v[1] *= T_val
+                    case c:
+                        raise ValueError(f"Got unexpected gate {c}")
+
+            global_phase = -rounded_parameter / 2 - numpy.angle(v[0])
+            result += GlobalPhase(angle=global_phase)
+            pauli_dict[bucket] = result
 
         if gate.name.lower() in ["rx", "ry"]:
             result = H(target=gate.target) + result + H(target=gate.target)

--- a/tests/test_recompilation_routines.py
+++ b/tests/test_recompilation_routines.py
@@ -173,7 +173,7 @@ def test_compile_pauli_rotations(type, angle: float):
     gate = type(target=0, angle=angle)
     compiler = CircuitCompiler(pauli_rotations=True, epsilon=1e-6)
     compiled = compiler.compile_circuit(gate)
-    assert np.allclose(gate.to_matrix(), compiled.to_matrix(), atol=1e-6)
+    np.testing.assert_allclose(gate.to_matrix(), compiled.to_matrix(), atol=1e-6)
 
 
 # Check if the gate is in the set {H, X, S, CNOT, T}

--- a/tests/test_recompilation_routines.py
+++ b/tests/test_recompilation_routines.py
@@ -208,7 +208,7 @@ def test_error_correctable_compilation():
     compiled = compiler.compile_circuit(U)
 
     assert all(is_error_correctable_gate(g) for g in compiled.gates)
-    assert np.allclose(U.to_matrix(), compiled.to_matrix(), atol=1e-5)
+    assert np.linalg.norm(U.to_matrix() - compiled.to_matrix(), ord=2) < 1e-5
 
 
 def test_compile_qubit_excitations():


### PR DESCRIPTION
For some reason this gives more efficient gate decompositions.

This fixes the problems I pointed out in #464.

I also fixed the `compile_toffoli` function, which was not doing anything previously. Not sure if this was necessary.