### PR TITLE
Allow caching subcircuits

### DIFF
--- a/src/tequila/circuit/_gates_impl.py
+++ b/src/tequila/circuit/_gates_impl.py
@@ -72,7 +72,8 @@ class QGateImpl:
         self._target = tuple(list_assignment(target))
         self._control = tuple(list_assignment(control))
         self.finalize()
-        self.generator = generator
+        if generator:
+            self.generator = generator
 
     def copy(self):
         return copy.deepcopy(self)

--- a/src/tequila/circuit/circuit.py
+++ b/src/tequila/circuit/circuit.py
@@ -1060,3 +1060,20 @@ def find_unused_qubit(U0: QCircuit = None, U1: QCircuit = None) -> int:
     assert free_qubit not in active_qubits
 
     return free_qubit
+
+
+class SubcircuitGate(QGateImpl):
+    """
+    Wraps a QCircuit object. When this is added to another circuit,
+    the structure of this subcircuit is kept (instead of flattening
+    it to a list of basic gates). This allows reusing this subcircuit
+    and e.g. compilation results while only storing it once. For
+    example, this is useful when building QSVT circuits.
+    """
+
+    def __init__(self, circuit: QCircuit):
+        super().__init__(name="CachedSubcircuit", target=tuple(range(circuit.n_qubits)))
+        self.circuit = circuit
+
+    def dagger(self):
+        return SubcircuitGate(self.circuit.dagger())

--- a/src/tequila/circuit/circuit.py
+++ b/src/tequila/circuit/circuit.py
@@ -718,6 +718,9 @@ class QCircuit:
 
         return QCircuit(gates=new_gates)
 
+    def as_subcircuit_gate(self) -> QCircuit:
+        return QCircuit.wrap_gate(SubcircuitGate(self))
+
 
 class Moment(QCircuit):
     """

--- a/src/tequila/circuit/compiler.py
+++ b/src/tequila/circuit/compiler.py
@@ -2,7 +2,7 @@ import numbers
 import warnings
 
 from tequila import TequilaException
-from tequila.circuit.circuit import QCircuit
+from tequila.circuit.circuit import QCircuit, SubcircuitGate
 from tequila.circuit.gates import Rx, Ry, H, X, S, Rz, ExpPauli, CNOT, Phase, T, Z, GlobalPhase
 from tequila.circuit._gates_impl import (
     RotationGateImpl,
@@ -318,7 +318,16 @@ class CircuitCompiler:
         # Keep a dicitionary of compiled pauli_rotations
         pauli_dict = {}
 
+        compiled_subcircuits = {}
+
         for idx, gate in gatelist:
+            if isinstance(gate, SubcircuitGate):
+                if id(gate.circuit) not in compiled_subcircuits:
+                    compiled_subcircuits[id(gate.circuit)] = self.compile_circuit(gate.circuit)
+                cg = compiled_subcircuits[id(gate.circuit)]
+                compiled_gates.append((idx, cg))
+                continue
+
             cg = gate
             controlled = gate.is_controlled()
 

--- a/src/tequila/circuit/gates.py
+++ b/src/tequila/circuit/gates.py
@@ -1,4 +1,4 @@
-from tequila.circuit.circuit import QCircuit
+from tequila.circuit.circuit import QCircuit, SubcircuitGate
 from tequila.objective.objective import Variable, assign_variable
 from tequila.circuit import _gates_impl as impl
 import typing
@@ -1342,3 +1342,7 @@ def PauliGate(
             raise Exception("{}???".format(v))
 
     return U
+
+
+def cached_subcircuit(circuit: QCircuit) -> QCircuit:
+    return QCircuit.wrap_gate(SubcircuitGate(circuit))

--- a/src/tequila/circuit/gates.py
+++ b/src/tequila/circuit/gates.py
@@ -1342,7 +1342,3 @@ def PauliGate(
             raise Exception("{}???".format(v))
 
     return U
-
-
-def cached_subcircuit(circuit: QCircuit) -> QCircuit:
-    return QCircuit.wrap_gate(SubcircuitGate(circuit))

--- a/src/tequila/simulators/simulator_base.py
+++ b/src/tequila/simulators/simulator_base.py
@@ -1,6 +1,6 @@
 from tequila.circuit._gates_impl import GlobalPhaseGateImpl
 from tequila.utils import TequilaException, to_float, TequilaWarning
-from tequila.circuit.circuit import QCircuit
+from tequila.circuit.circuit import QCircuit, SubcircuitGate
 from tequila.utils.keymap import KeyMapSubregisterToRegister
 from tequila.utils.misc import to_float
 from tequila.wavefunction.qubit_wavefunction import QubitWaveFunction
@@ -314,7 +314,9 @@ class BackendCircuit:
             result = self.initialize_circuit(*args, **kwargs)
 
         for g in abstract_circuit.gates:
-            if g.is_parameterized():
+            if isinstance(g, SubcircuitGate):
+                self.create_circuit(g.circuit, result)
+            elif g.is_parameterized():
                 self.add_parametrized_gate(g, result, *args, **kwargs)
             else:
                 self.add_basic_gate(g, result, *args, **kwargs)


### PR DESCRIPTION
This adds the `cached_subcircuit` function which converts a `QCircuit` object to a `SubcircuitGate` object.
When this is added to another circuit, it is treated like a gate (unlike a normal circuit where all the gates are appended directly to the existing gates, and there's no subcircuit). This means that it only needs to be compiled once, and should also save some memory.

This is currently a very simple implementation that only caches the Tequila Compilation, nothing backend specific, but it can already speed up circuit Compilation significantly:

The following code takes me around 10 seconds to run:

```python
import time
import tequila as tq
from tequila import CircuitCompiler
from tequila.circuit.gates import cached_subcircuit

subcircuit = tq.QCircuit()
for i in range(10):
    subcircuit += tq.gates.Ry(angle=i, target=0)

circuit = tq.QCircuit()
for i in range(100):
    circuit += subcircuit

start = time.time()
compiled = CircuitCompiler.error_correctable_gate_set(1e-6).compile_circuit(circuit)
print(f"Compilation time: {time.time() - start} s")
```

Replacing `circuit += subcircuit` with `circuit += cached_subcircuit(subcircuit)` decreases this time to ~0.7 seconds, while (in theory) being functionally equivalent.